### PR TITLE
fix(sanctum): add hooks directory to coverage configuration

### DIFF
--- a/plugins/sanctum/pyproject.toml
+++ b/plugins/sanctum/pyproject.toml
@@ -67,6 +67,7 @@ addopts = [
     "-v",
     "--strict-markers",
     "--cov=src/sanctum",
+    "--cov=hooks",
     "--cov-report=term-missing",
     "--cov-report=html",
 ]
@@ -80,7 +81,7 @@ markers = [
 ]
 
 [tool.coverage.run]
-source = ["src/sanctum"]
+source = ["src/sanctum", "hooks"]
 omit = ["tests/*", "*/tests/*", "*/__pycache__/*"]
 
 [tool.coverage.report]


### PR DESCRIPTION
  Fixes #173                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                 
  Coverage was reporting 0.00% for session_complete_notify tests because the hooks                                                                                                                                                               
  directory was not included in the coverage source paths.                                                                                                                                                                                       
                                                                                                                                                                                                                                                 
  ## Changes                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                 
  - Added `--cov=hooks` to pytest addopts                                                                                                                                                                                                        
  - Added `hooks` to `[tool.coverage.run]` source list                                                                                                                                                                                           
                                                                                                                                                                                                                                                 
  ## Test Plan                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                 
  - [x] `session_complete_notify.py` now shows 64% coverage (was 0%)                                                                                                                                                                             
  - [x] All 42 notification tests pass                                                                                                                                                                                                           
  - [x] Full test suite passes (404/405 - 1 unrelated pre-existing failure)        