### PR TITLE
feat(scribe): add session-to-post skill

### DIFF
--- a/plugins/scribe/.claude-plugin/plugin.json
+++ b/plugins/scribe/.claude-plugin/plugin.json
@@ -5,14 +5,16 @@
   "commands": [
     "./commands/doc-generate.md",
     "./commands/doc-polish.md",
-    "./commands/style-learn.md"
+    "./commands/style-learn.md",
+    "./commands/session-to-post.md"
   ],
   "skills": [
     "./skills/slop-detector",
     "./skills/style-learner",
     "./skills/doc-generator",
     "./skills/doc-importer",
-    "./skills/tech-tutorial"
+    "./skills/tech-tutorial",
+    "./skills/session-to-post"
   ],
   "agents": [
     "./agents/doc-editor.md",

--- a/plugins/scribe/commands/session-to-post.md
+++ b/plugins/scribe/commands/session-to-post.md
@@ -1,0 +1,72 @@
+# Session to Post
+
+Convert the current session's work into a shareable blog post, case study, or social thread.
+
+## Usage
+
+```bash
+/session-to-post [format] [options]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `format` | Output format: `blog` (default), `case-study`, `thread` |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--output` | Output file path (default: `docs/posts/`) |
+| `--since` | Git ref or date for session start (default: last 20 commits) |
+| `--record` | Generate scry recordings: `terminal`, `browser`, `both`, `none` (default: `none`) |
+| `--verify` | Run proof-of-work on all claims (default: true) |
+
+## Workflow
+
+1. Invoke `Skill(scribe:session-to-post)` to run the full pipeline
+2. If `--record terminal`: invoke `Skill(scry:vhs-recording)` for test/build GIFs
+3. If `--record browser`: invoke `Skill(scry:browser-recording)` for app demo GIFs
+4. If `--record both`: invoke both, then `Skill(scry:media-composition)` to combine
+5. Invoke `Skill(imbue:proof-of-work)` to verify all claims
+6. Invoke `Skill(scribe:slop-detector)` for final quality pass
+
+## Examples
+
+```bash
+# Quick blog post from recent work
+/session-to-post
+
+# Case study with terminal recording
+/session-to-post case-study --record terminal
+
+# Social thread, work since a specific commit
+/session-to-post thread --since abc1234
+
+# Blog post with all recordings, custom output
+/session-to-post blog --record both --output blog/q2-port.md
+```
+
+## Output
+
+Generated file with quality report:
+
+```
+Generated: docs/posts/2026-03-26-rewriting-quake2-in-rust.md (1,180 words)
+
+Quality:
+- Slop score: 1.2 (clean)
+- Verifiable claims: 8, all PASS
+- Recordings: tests.gif, demo.gif
+
+Assets written to docs/posts/assets/
+```
+
+## See Also
+
+- `Skill(scribe:session-to-post)` — full skill reference
+- `Skill(scry:vhs-recording)` — terminal recordings
+- `Skill(scry:browser-recording)` — browser recordings
+- `Skill(imbue:proof-of-work)` — claim verification
+- `/doc-generate` — general documentation generation

--- a/plugins/scribe/openpackage.yml
+++ b/plugins/scribe/openpackage.yml
@@ -25,10 +25,12 @@ skills:
 - skills/style-learner
 - skills/doc-generator
 - skills/tech-tutorial
+- skills/session-to-post
 commands:
 - commands/doc-generate.md
 - commands/doc-polish.md
 - commands/style-learn.md
+- commands/session-to-post.md
 agents:
 - agents/doc-editor.md
 - agents/slop-hunter.md

--- a/plugins/scribe/skills/session-to-post/SKILL.md
+++ b/plugins/scribe/skills/session-to-post/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: session-to-post
+description: Convert a Claude Code session into a shareable blog post or case study
+  capturing what was built, decisions made, and outcomes achieved.
+  Use when finishing a session and wanting to share the process, or
+  when creating marketing content from real development work.
+  Do not use for API docs (use doc-generator) or tutorials (use tech-tutorial).
+version: 1.7.1
+globs: "**/*.md"
+alwaysApply: false
+category: artifact-generation
+tags:
+- blog
+- marketing
+- session-capture
+- case-study
+- storytelling
+- developer-experience
+tools:
+- Read
+- Write
+- Edit
+- Bash
+- Glob
+- Grep
+- TodoWrite
+complexity: medium
+estimated_tokens: 2500
+progressive_loading: true
+modules:
+- session-extraction
+- narrative-structure
+dependencies:
+- scribe:shared
+- scribe:slop-detector
+---
+
+# Session to Post
+
+Capture what happened in a Claude Code session and turn it into a
+blog post, case study, or social media thread that others can learn from.
+
+The skill extracts the real story from git history, file changes, and
+conversation context — then shapes it into a narrative that shows
+process, not just results.
+
+## When To Use
+
+- After completing a meaningful chunk of work you want to share
+- Creating dev blog content from real sessions
+- Building case studies for tools, libraries, or techniques
+- Producing marketing content that demonstrates capability
+- Documenting a process for teammates who weren't in the session
+
+## When NOT To Use
+
+- Writing API reference documentation (use `scribe:doc-generator`)
+- Creating step-by-step tutorials (use `scribe:tech-tutorial`)
+- Cleaning up existing prose (use `scribe:slop-detector`)
+- Internal project documentation (use `sanctum:doc-updates`)
+
+## Integration Points
+
+This skill connects to several others in the ecosystem.
+Use them when the post needs more than prose.
+
+| Need | Skill | What it adds |
+|------|-------|-------------|
+| Terminal demo GIF | `scry:vhs-recording` | Record a build/test run as an animated GIF |
+| Browser demo GIF | `scry:browser-recording` | Capture a web UI walkthrough via Playwright |
+| Composite media | `scry:media-composition` | Stitch terminal + browser GIFs side-by-side |
+| Proof of claims | `imbue:proof-of-work` | Verify every number in the post with evidence |
+| Code quality narrative | `pensive:code-refinement` | Describe what was cleaned up and why |
+| Review narrative | `imbue:structured-review` | Capture review findings as post content |
+| Change summary | `imbue:catchup` | Summarize what changed for the post's "The Work" section |
+| Diff analysis | `imbue:diff-analysis` | Risk-scored change breakdown for technical audiences |
+
+### Recording Integration (scry)
+
+When the post describes something visual — a running app, a test suite,
+a build pipeline — capture it instead of describing it.
+
+**Terminal recordings** (build output, test runs, CLI demos):
+```
+Invoke Skill(scry:vhs-recording) with a tape that runs:
+  make test        → shows 180 tests passing
+  make play        → shows the build + server startup
+```
+
+**Browser recordings** (web apps, rendered output):
+```
+Invoke Skill(scry:browser-recording) with a Playwright spec that:
+  navigates to the app
+  interacts with it
+  captures the result
+```
+
+**Composition** (side-by-side before/after, terminal + browser):
+```
+Invoke Skill(scry:media-composition) to stitch recordings into
+a single visual that tells the story.
+```
+
+Place generated GIFs in `docs/posts/assets/` and reference them
+from the markdown with relative paths.
+
+### Proof-of-Work Integration (imbue)
+
+Every claim in the post should be verifiable. Before finalizing:
+
+```
+Invoke Skill(imbue:proof-of-work) to:
+  - Tag each claim with [E1], [E2], etc.
+  - Run verification commands
+  - Report PASS / FAIL / BLOCKED
+```
+
+This prevents publishing posts with stale numbers or broken examples.
+
+## Methodology
+
+### Step 1: Extract Session Context
+
+Load the `session-extraction` module for the full checklist.
+
+Gather raw material from what actually happened:
+
+1. **Git history** — commits since the session started:
+   ```bash
+   git log --oneline --since="<session_start>" --stat
+   ```
+2. **File inventory** — what was created and changed:
+   ```bash
+   git diff --stat <start_commit>..HEAD
+   ```
+3. **Test results** — concrete evidence of what works:
+   ```bash
+   cargo test  # or the project's test command
+   ```
+4. **Metrics** — scope and scale:
+   ```bash
+   find . -name "*.rs" -not -path "*/target/*" | xargs wc -l
+   ```
+5. **Conversation context** — the user's goals, constraints, and decisions
+   made during the session
+
+### Step 2: Identify the Story
+
+Every session post answers three questions:
+
+1. **What were we trying to do?** — the goal, not the task list
+2. **What did we actually do?** — the real path, including pivots
+3. **What came out of it?** — concrete, measurable results
+
+Look for:
+- **The hook** — what makes this interesting? A hard problem, a
+  surprising approach, an impressive result
+- **Turning points** — where did the plan change? What broke?
+  What worked unexpectedly?
+- **The number** — one metric that captures the outcome
+  (lines written, tests passing, performance gain, time saved)
+
+### Step 3: Draft the Post
+
+Load the `narrative-structure` module for formatting templates.
+
+**Structure** (adapt to content):
+
+```markdown
+# Title: [Verb] + [What] + [With What]
+
+## Opening (2-3 sentences)
+What we set out to do and why. No throat-clearing.
+
+## Starting Point
+Where things stood before. Concrete: file counts, code state,
+what worked and what didn't.
+
+## The Work
+Key phases. Focus on decisions and pivots, not keystrokes.
+- Phase 1: [what and why]
+- Phase 2: [what and why]
+Include GIFs from scry recordings where visual.
+
+## How We Tested It
+What verification looked like. Show the test run, the proof-of-work
+evidence. Include terminal recording GIF of tests passing.
+
+## Results
+Hard numbers. Before/after. What works now.
+Screenshots or browser recording GIF if visual.
+
+## What's Next
+Honest remaining work. No false completeness.
+```
+
+**Tone**:
+- Write like explaining to a colleague over coffee
+- Specifics over adjectives ("180 tests" not "comprehensive suite")
+- Show the mess — readers connect with pivots and debugging
+- Credit the tools and techniques that made it work
+- Under 1500 words unless the content demands more
+
+### Step 4: Quality Gate
+
+1. **Slop check** — `Skill(scribe:slop-detector)` on the draft
+2. **Proof-of-work** — `Skill(imbue:proof-of-work)` on all claims
+3. **Recording check** — does any section need a GIF?
+4. **Title test** — would you click this? Does it promise something specific?
+5. **Opening test** — does paragraph one say what the post is about?
+
+### Step 5: Output
+
+Write the post to the requested location (default: `docs/posts/`).
+
+Report:
+- Word count
+- Slop score
+- Verifiable claims count
+- Recordings generated (if any)
+
+## Example
+
+A session that ported a Quake 2 engine from C to Rust:
+
+> **Title**: Rewriting a Quake 2 Engine in Rust with Claude Code
+>
+> **Opening**: We took a 150,000-line C game engine and started
+> rewriting it in Rust targeting WebAssembly. In one session we went
+> from an empty workspace to a prototype loading real game data in
+> the browser.
+>
+> **Starting point**: A Yamagi Quake II fork compiled with Emscripten.
+> Goal: idiomatic Rust with wasm-bindgen, glow for WebGL2, and
+> matchbox for P2P multiplayer.
+>
+> **The work**: Seven parallel agents built subsystems — collision,
+> movement, filesystem, networking, renderer, server, client — while
+> the main session coordinated integration. A Makefile with
+> prerequisite checks automated the full build-to-browser pipeline
+> including game data download.
+>
+> **How we tested**: 180 unit tests across 13 crates. BSP loading
+> verified against real Quake 2 demo pak0.pak. Browser diagnostics
+> logged every init step. [Terminal GIF: `make test` output]
+>
+> **Results**: 10,950 lines of Rust, 180 tests, real game data
+> loading and flat-shaded BSP rendering in the browser with WASD
+> movement and mouse look.
+>
+> **What's next**: Textured rendering, collision debugging, sound,
+> menus, multiplayer.
+
+Every claim is checkable — line counts from `wc -l`, test counts
+from `cargo test`, file counts from filesystem log output.

--- a/plugins/scribe/skills/session-to-post/modules/narrative-structure.md
+++ b/plugins/scribe/skills/session-to-post/modules/narrative-structure.md
@@ -1,0 +1,142 @@
+---
+module: narrative-structure
+category: writing-quality
+dependencies: []
+estimated_tokens: 450
+---
+
+# Narrative Structure
+
+Templates and patterns for turning a session brief into a post.
+
+## Post Formats
+
+### Blog Post (default)
+
+Best for: dev blogs, company engineering blogs, personal sites.
+
+```markdown
+# [Verb]ing [What] [With/In/Using What]
+
+[2-3 sentence opener. State what was done and the headline result.
+No "In this post we will..." — just say the thing.]
+
+## Where We Started
+
+[Concrete starting state. Numbers, not adjectives.
+"A 150K-line C codebase" not "a large legacy codebase."]
+
+## What We Built
+
+### [Phase/Decision 1 name]
+
+[What and why. 2-4 sentences. Code snippet only if it
+illustrates a technique worth sharing.]
+
+### [Phase/Decision 2 name]
+
+[Same pattern. Focus on the interesting parts — skip
+anything a reader could guess.]
+
+![Terminal recording of tests passing](assets/tests.gif)
+
+## How We Verified It
+
+[Show the proof. Test output, before/after measurements,
+screenshots. This is where recordings from scry belong.]
+
+![Browser recording of the running app](assets/demo.gif)
+
+## Results
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Lines of code | 0 | 10,950 |
+| Tests passing | 0 | 180 |
+| Build target | Emscripten | wasm-pack |
+
+## What's Left
+
+[Honest list. Readers respect knowing what isn't done.]
+
+- [ ] Remaining item 1
+- [ ] Remaining item 2
+```
+
+### Case Study
+
+Best for: marketing, demonstrating tool capability to prospects.
+
+```markdown
+# [Outcome]: [How]
+
+## The Challenge
+
+[1 paragraph. What problem needed solving and why it was hard.]
+
+## The Approach
+
+[Walk through the method. Emphasize decisions, not steps.
+Show how the tool/technique enabled the outcome.]
+
+## The Evidence
+
+[Hard numbers. Before/after. Screenshots and recordings.]
+
+## Key Takeaways
+
+1. [Insight that generalizes beyond this project]
+2. [Insight about the tool or technique]
+3. [What would change if doing it again]
+```
+
+### Social Thread
+
+Best for: Twitter/X, Bluesky, LinkedIn.
+
+```
+1/ [Hook: the result in one sentence]
+
+2/ Starting point: [concrete state before]
+
+3/ The approach: [key technique in 1-2 sentences]
+
+4/ [The interesting part — a decision, a pivot, a surprise]
+
+5/ Results: [numbers]
+
+6/ What's next: [honest assessment]
+
+[Attach: GIF from scry recording, screenshot of output]
+```
+
+## Writing Rules
+
+1. **Lead with the result**, not the process
+2. **One number per section** minimum — ground every claim
+3. **Show, don't summarize** — a GIF of tests passing says more
+   than "we wrote comprehensive tests"
+4. **Name the tools** — readers want to know how, not just what
+5. **Include a pivot** — straight-line success stories aren't
+   believable or interesting
+6. **End with honesty** — what's unfinished, what you'd change
+
+## Title Patterns That Work
+
+- `[Verb]ing [Big Thing] in [Constraint]`
+  — "Porting a Game Engine to Rust in One Session"
+- `How We [Achieved Result] with [Tool/Technique]`
+  — "How We Hit 180 Tests in 3 Hours with Parallel Agents"
+- `[Number] [Things] I Learned [Doing X]`
+  — "5 Things I Learned Rewriting C as Rust for WebAssembly"
+- `From [State A] to [State B]: [How]`
+  — "From Empty Repo to Playable Game: A Claude Code Session"
+
+## Anti-Patterns
+
+- "In this blog post, we will explore..." — skip the preamble
+- "It's worth noting that..." — if it's worth noting, just note it
+- Listing every file changed — nobody cares about the full diff
+- Explaining things the audience already knows
+- Screenshots of code when a link to the repo would do
+- Claiming something works without showing evidence

--- a/plugins/scribe/skills/session-to-post/modules/session-extraction.md
+++ b/plugins/scribe/skills/session-to-post/modules/session-extraction.md
@@ -1,0 +1,110 @@
+---
+module: session-extraction
+category: data-gathering
+dependencies: []
+estimated_tokens: 400
+---
+
+# Session Extraction Checklist
+
+Run these commands and capture the output. This is the raw
+material the narrative is built from.
+
+## Git History
+
+```bash
+# Commits this session (adjust date/hash as needed)
+git log --oneline --stat HEAD~20..HEAD
+
+# Files changed summary
+git diff --stat <start_commit>..HEAD
+
+# Diff size
+git diff --shortstat <start_commit>..HEAD
+```
+
+Capture: commit messages, files touched, insertions/deletions.
+
+## Codebase Metrics
+
+```bash
+# Lines of code (adjust extension for language)
+find . -name "*.rs" -not -path "*/target/*" | xargs wc -l | tail -1
+find . -name "*.py" -not -path "*venv*" | xargs wc -l | tail -1
+find . -name "*.ts" -not -path "*node_modules*" | xargs wc -l | tail -1
+
+# File count
+find . -name "*.rs" -not -path "*/target/*" | wc -l
+
+# Test count
+cargo test 2>&1 | grep "test result"
+# or: pytest --co -q 2>&1 | tail -1
+# or: npm test 2>&1 | grep "Tests:"
+```
+
+Capture: total lines, file count, test count + pass/fail.
+
+## Architecture
+
+```bash
+# Directory tree (depth 3)
+find . -type d -not -path "*/target/*" -not -path "*node_modules*" \
+  -maxdepth 3 | sort
+
+# Key config files
+cat Cargo.toml  # or package.json, pyproject.toml
+```
+
+Capture: project structure, dependency count, crate/package organization.
+
+## Build and Runtime
+
+```bash
+# Build output (note timing)
+time cargo build --release 2>&1 | tail -5
+
+# Binary/artifact size
+ls -lh target/release/*.wasm dist/*.html 2>/dev/null
+```
+
+Capture: build time, artifact sizes.
+
+## Conversation Context
+
+These come from the session itself, not from commands:
+
+- **Initial goal** — what the user asked for
+- **Constraints** — time, tech stack, compatibility requirements
+- **Key decisions** — why X over Y at each fork
+- **Pivots** — where the plan changed and why
+- **Blockers hit** — what went wrong and how it was resolved
+- **Tools used** — parallel agents, specific skills invoked
+
+## Output Format
+
+Compile extraction results into a structured brief:
+
+```markdown
+## Session Brief
+
+**Goal**: [one sentence]
+**Duration**: [approximate]
+**Starting state**: [what existed before]
+
+### Metrics
+- Lines written: X
+- Files created/modified: Y
+- Tests: Z passing
+
+### Key commits
+1. [hash] [message] — [significance]
+2. ...
+
+### Decisions
+1. [decision] because [reason]
+2. ...
+
+### Pivots
+1. [what changed] because [what happened]
+2. ...
+```

--- a/plugins/scribe/tests/unit/skills/test_session_to_post.py
+++ b/plugins/scribe/tests/unit/skills/test_session_to_post.py
@@ -1,0 +1,337 @@
+"""Tests for session-to-post skill structure and content.
+
+Validates that the skill file, module files, command file, and plugin
+registration all exist and contain the required fields. Follows the
+BDD-style pattern used across skill tests in this project.
+"""
+
+from pathlib import Path
+
+import pytest
+
+SKILL_ROOT = Path(__file__).parents[3] / "skills" / "session-to-post"
+MODULES_ROOT = SKILL_ROOT / "modules"
+COMMANDS_ROOT = Path(__file__).parents[3] / "commands"
+OPENPACKAGE = Path(__file__).parents[3] / "openpackage.yml"
+
+
+class TestSessionToPostSkillExists:
+    """Feature: session-to-post skill files are present on disk.
+
+    As a developer using the scribe plugin
+    I want the session-to-post skill to be installed
+    So that I can convert sessions into blog posts
+    """
+
+    @pytest.fixture
+    def skill_path(self) -> Path:
+        return SKILL_ROOT / "SKILL.md"
+
+    @pytest.fixture
+    def session_extraction_module(self) -> Path:
+        return MODULES_ROOT / "session-extraction.md"
+
+    @pytest.fixture
+    def narrative_structure_module(self) -> Path:
+        return MODULES_ROOT / "narrative-structure.md"
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_skill_md_exists(self, skill_path: Path) -> None:
+        """Scenario: SKILL.md exists at the expected path.
+
+        Given the scribe plugin
+        When checking for the session-to-post skill
+        Then SKILL.md should exist under skills/session-to-post/
+        """
+        assert skill_path.exists(), f"SKILL.md not found at {skill_path}"
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_session_extraction_module_exists(
+        self, session_extraction_module: Path
+    ) -> None:
+        """Scenario: session-extraction module exists.
+
+        Given the session-to-post skill
+        When checking for its modules
+        Then session-extraction.md should exist under modules/
+        """
+        assert session_extraction_module.exists(), (
+            f"session-extraction.md not found at {session_extraction_module}"
+        )
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_narrative_structure_module_exists(
+        self, narrative_structure_module: Path
+    ) -> None:
+        """Scenario: narrative-structure module exists.
+
+        Given the session-to-post skill
+        When checking for its modules
+        Then narrative-structure.md should exist under modules/
+        """
+        assert narrative_structure_module.exists(), (
+            f"narrative-structure.md not found at {narrative_structure_module}"
+        )
+
+
+class TestSessionToPostFrontmatter:
+    """Feature: SKILL.md has valid YAML frontmatter.
+
+    As a plugin loader
+    I want the skill to declare its metadata
+    So that it can be discovered and loaded correctly
+    """
+
+    @pytest.fixture
+    def skill_content(self) -> str:
+        return (SKILL_ROOT / "SKILL.md").read_text()
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_has_frontmatter_delimiters(self, skill_content: str) -> None:
+        """Scenario: File begins with YAML frontmatter.
+
+        Given the session-to-post SKILL.md
+        When reading the file
+        Then it should begin with '---' frontmatter delimiters
+        """
+        assert skill_content.startswith("---")
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_has_name_field(self, skill_content: str) -> None:
+        """Scenario: Frontmatter declares the skill name.
+
+        Given the session-to-post SKILL.md
+        When reading the frontmatter
+        Then it should contain 'name: session-to-post'
+        """
+        assert "name: session-to-post" in skill_content
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_has_category_field(self, skill_content: str) -> None:
+        """Scenario: Frontmatter declares a category."""
+        assert "category:" in skill_content
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_has_tags_field(self, skill_content: str) -> None:
+        """Scenario: Frontmatter declares tags."""
+        assert "tags:" in skill_content
+        assert "blog" in skill_content
+        assert "marketing" in skill_content
+        assert "session-capture" in skill_content
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_has_complexity_field(self, skill_content: str) -> None:
+        """Scenario: Frontmatter declares complexity."""
+        assert "complexity:" in skill_content
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_has_estimated_tokens(self, skill_content: str) -> None:
+        """Scenario: Frontmatter declares token budget."""
+        assert "estimated_tokens:" in skill_content
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_has_modules_list(self, skill_content: str) -> None:
+        """Scenario: Frontmatter lists both modules."""
+        assert "modules:" in skill_content
+        assert "session-extraction" in skill_content
+        assert "narrative-structure" in skill_content
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_has_dependencies(self, skill_content: str) -> None:
+        """Scenario: Frontmatter declares scribe dependencies."""
+        assert "dependencies:" in skill_content
+        assert "scribe:slop-detector" in skill_content
+
+
+class TestSessionToPostIntegrationPoints:
+    """Feature: Skill documents integration with other plugins.
+
+    As a content creator
+    I want session-to-post to integrate with scry and imbue
+    So that posts include recordings and verified claims
+    """
+
+    @pytest.fixture
+    def skill_content(self) -> str:
+        return (SKILL_ROOT / "SKILL.md").read_text()
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_references_scry_vhs(self, skill_content: str) -> None:
+        """Scenario: Skill references terminal recording.
+
+        Given the session-to-post skill
+        When reading integration points
+        Then it should reference scry:vhs-recording
+        """
+        assert "scry:vhs-recording" in skill_content
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_references_scry_browser(self, skill_content: str) -> None:
+        """Scenario: Skill references browser recording.
+
+        Given the session-to-post skill
+        When reading integration points
+        Then it should reference scry:browser-recording
+        """
+        assert "scry:browser-recording" in skill_content
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_references_scry_composition(self, skill_content: str) -> None:
+        """Scenario: Skill references media composition.
+
+        Given the session-to-post skill
+        When reading integration points
+        Then it should reference scry:media-composition
+        """
+        assert "scry:media-composition" in skill_content
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_references_proof_of_work(self, skill_content: str) -> None:
+        """Scenario: Skill references proof-of-work for claims.
+
+        Given the session-to-post skill
+        When reading integration points
+        Then it should reference imbue:proof-of-work
+        """
+        assert "imbue:proof-of-work" in skill_content
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_references_catchup(self, skill_content: str) -> None:
+        """Scenario: Skill references catchup for change summaries.
+
+        Given the session-to-post skill
+        When reading integration points
+        Then it should reference imbue:catchup
+        """
+        assert "imbue:catchup" in skill_content
+
+
+class TestSessionToPostContent:
+    """Feature: Skill body covers the full methodology.
+
+    As a user following the skill
+    I want clear steps from extraction to output
+    So that I produce a quality post every time
+    """
+
+    @pytest.fixture
+    def skill_content(self) -> str:
+        return (SKILL_ROOT / "SKILL.md").read_text()
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_has_extraction_step(self, skill_content: str) -> None:
+        """Scenario: Methodology includes session extraction."""
+        assert "Extract Session Context" in skill_content
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_has_story_step(self, skill_content: str) -> None:
+        """Scenario: Methodology includes story identification."""
+        assert "Identify the Story" in skill_content
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_has_draft_step(self, skill_content: str) -> None:
+        """Scenario: Methodology includes drafting."""
+        assert "Draft the Post" in skill_content
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_has_quality_gate(self, skill_content: str) -> None:
+        """Scenario: Methodology includes quality gate."""
+        assert "Quality Gate" in skill_content
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_has_testing_section_in_template(self, skill_content: str) -> None:
+        """Scenario: Post template includes how-we-tested section.
+
+        Given the session-to-post skill
+        When reading the draft template
+        Then it should include a testing narrative section
+        """
+        assert "How We Tested" in skill_content
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_has_example(self, skill_content: str) -> None:
+        """Scenario: Skill includes a concrete example."""
+        assert "## Example" in skill_content
+
+
+class TestSessionToPostCommand:
+    """Feature: A command file exists to invoke the skill.
+
+    As a user
+    I want a /session-to-post slash command
+    So that I can invoke the skill quickly
+    """
+
+    @pytest.fixture
+    def command_path(self) -> Path:
+        return COMMANDS_ROOT / "session-to-post.md"
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_command_file_exists(self, command_path: Path) -> None:
+        """Scenario: Command file exists.
+
+        Given the scribe plugin
+        When checking for the session-to-post command
+        Then session-to-post.md should exist under commands/
+        """
+        assert command_path.exists(), f"Command not found at {command_path}"
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_command_references_skill(self, command_path: Path) -> None:
+        """Scenario: Command invokes the skill.
+
+        Given the session-to-post command
+        When reading its content
+        Then it should reference Skill(scribe:session-to-post)
+        """
+        content = command_path.read_text()
+        assert "scribe:session-to-post" in content
+
+
+class TestSessionToPostRegistration:
+    """Feature: Skill and command registered in openpackage.yml.
+
+    As a plugin loader
+    I want session-to-post in the package manifest
+    So that the system discovers and loads it
+    """
+
+    @pytest.fixture
+    def openpackage_content(self) -> str:
+        return OPENPACKAGE.read_text()
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_skill_registered(self, openpackage_content: str) -> None:
+        """Scenario: Skill listed in openpackage.yml skills."""
+        assert "skills/session-to-post" in openpackage_content
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_command_registered(self, openpackage_content: str) -> None:
+        """Scenario: Command listed in openpackage.yml commands."""
+        assert "commands/session-to-post.md" in openpackage_content


### PR DESCRIPTION
## Summary

- New `session-to-post` skill that converts Claude Code sessions into shareable blog posts, case studies, or social threads
- Extracts real data from git history, test results, and metrics — no manual summarization
- Integrates with scry (terminal/browser recordings), imbue (proof-of-work claim verification), and slop-detector (prose quality)

## What's included

| File | Purpose |
|------|---------|
| `skills/session-to-post/SKILL.md` | Main skill — 5-step methodology: extract → story → draft → quality gate → output |
| `skills/session-to-post/modules/session-extraction.md` | Checklist for gathering git history, metrics, and conversation context |
| `skills/session-to-post/modules/narrative-structure.md` | Templates for blog, case study, and social thread formats |
| `commands/session-to-post.md` | `/session-to-post` command with format and recording options |
| `tests/unit/skills/test_session_to_post.py` | 26 BDD tests covering structure, frontmatter, integrations, content, and registration |
| `openpackage.yml` + `plugin.json` | Skill and command registered |

## Integration points

- `scry:vhs-recording` — terminal demo GIFs (build output, test runs)
- `scry:browser-recording` — web app demo GIFs via Playwright
- `scry:media-composition` — composite visuals (side-by-side terminal + browser)
- `imbue:proof-of-work` — verify every number in the post with evidence
- `imbue:catchup` — summarize changes for the "what we built" section
- `scribe:slop-detector` — final prose quality pass

## Test plan

- [x] 26 BDD tests passing locally
- [x] All pre-commit hooks passing (type check, meta-evaluation, ruff, bandit)
- [ ] CI passes