### PR TITLE
refactor: move stdlib imports to module level (#407)

### DIFF
--- a/plugins/egregore/scripts/notify.py
+++ b/plugins/egregore/scripts/notify.py
@@ -20,9 +20,11 @@ function without checking config itself.
 
 from __future__ import annotations
 
+import enum
 import importlib.util
 import logging
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -72,8 +74,6 @@ if _HERALD_AVAILABLE and _herald_mod is not None:
 # --- Stub fallbacks (when herald is absent) -------------------------
 
 else:
-    import enum
-    from dataclasses import dataclass
 
     class AlertEvent(enum.Enum):  # type: ignore[no-redef]  # conditional stub when herald absent
         """Stub alert events when herald is absent."""

--- a/plugins/gauntlet/hooks/precommit_gate.py
+++ b/plugins/gauntlet/hooks/precommit_gate.py
@@ -12,6 +12,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -213,8 +214,6 @@ def _graph_staleness_warning(
     Threshold is configurable via .gauntlet/config.json:
     {"stale_threshold_hours": 12}
     """
-    import time
-
     db_path = gauntlet_dir / "graph.db"
     if not db_path.exists():
         return None


### PR DESCRIPTION
## Summary

- Closes #407 — moves `import time` and `import enum` / `from dataclasses import dataclass` from inside function/else bodies to module-level import blocks
- Closes #375 — already implemented in commit 6097e6a0 (the FTS incremental-update fix landed in the #359–#377 batch); issue was left open by accident

## Changes

**`plugins/gauntlet/hooks/precommit_gate.py`**
- Added `import time` to module-level imports
- Removed `import time` from inside `_graph_staleness_warning()` body

**`plugins/egregore/scripts/notify.py`**
- Added `import enum` and `from dataclasses import dataclass` to module-level imports
- Removed the duplicate imports from inside the `else:` stub block
- Class definitions remain conditional (correct: they depend on herald presence), only the imports moved

## Why

stdlib modules are always available. Deferring them inside function bodies or conditional branches hides dependencies, confuses linters (ruff PLC0415), and provides no benefit over module-level placement.

## Test Plan

- [x] `test_stale_graph_warning.py` — 4 tests pass (`_graph_staleness_warning` covered)
- [x] egregore tests pass (65 tests)
- [x] Type check: egregore + gauntlet both clean (`mypy` green)
- [x] Ruff check + format pass
- [x] All pre-commit hooks pass

## Not in scope

Issues #388, #389, #392–394, #405, #406 from the 375–407 range remain open and are tracked separately (each is medium-to-large effort with its own spec/branch needs).