### PR TITLE
research(sanctum): stacked diff workflows ADR and skeleton skills (#405)

### DIFF
--- a/book/src/reference/capabilities-reference.md
+++ b/book/src/reference/capabilities-reference.md
@@ -153,6 +153,9 @@ See [Capabilities Reference Details](capabilities-reference-details.md).
 | `smart-sourcing` | [conserve](../plugins/conserve.md) | Balance accuracy with token efficiency |
 | `spec-writing` | [spec-kit](../plugins/spec-kit.md) | Specification authoring |
 | `speckit-orchestrator` | [spec-kit](../plugins/spec-kit.md) | Workflow coordination |
+| `stack-create` | [sanctum](../plugins/sanctum.md) | Initialize a branch stack from a multi-step plan |
+| `stack-push` | [sanctum](../plugins/sanctum.md) | Push stack branches and open or update dependent PRs |
+| `stack-rebase` | [sanctum](../plugins/sanctum.md) | Cascading rebase after a base PR merges |
 | `stewardship` | [leyline](../plugins/leyline.md) | Cross-cutting stewardship principles with layer-specific guidance |
 | `storage-templates` | [leyline](../plugins/leyline.md) | Storage abstraction patterns |
 | `structured-output` | [imbue](../plugins/imbue.md) | Formatting patterns |

--- a/docs/adr/0010-stacked-diff-workflows.md
+++ b/docs/adr/0010-stacked-diff-workflows.md
@@ -1,0 +1,183 @@
+# ADR-0010: Stacked Diff Workflows for Sanctum and Egregore
+
+**Date**: 2026-04-20
+**Status**: Accepted
+**Deciders**: Claude Night Market maintainers
+
+## Context
+
+Sanctum's current workflows assume linear branches.
+`/prepare-pr`, `/commit-msg`, and `/acp` each operate on
+a single feature branch targeting `master`.
+Egregore's parallel worktrees are independent with no
+dependency chains.
+Neither plugin models ordered PR stacks, cascading rebases
+after a base PR merges, or dependent PR submission sequences.
+
+As do-issue parallelism grows more coarse and plans routinely
+produce 3-5 interdependent changes, agents increasingly need
+to submit changes as a stack of dependent PRs rather than
+one monolithic PR or a collection of unrelated PRs.
+
+### Requirements
+
+- Submit a series of dependent changes as ordered PRs with
+  correct base-branch targeting
+- Rebase the entire stack automatically when a base PR
+  merges or its base changes
+- Keep the workflow zero-dependency by default (no third-party
+  tooling required)
+- Detect and use optional accelerators (jj) when available
+- Remain compatible with the existing sanctum/egregore
+  skill and hook architecture
+
+### Current Gaps
+
+| Gap | Affected Skill / Command |
+|-----|--------------------------|
+| Linear branch assumption | `/prepare-pr`, `/commit-msg`, `/acp` |
+| No dependency chains in worktrees | egregore parallel dispatch |
+| No cascading rebase support | all PR workflows |
+| Flat PR review (no stack context) | `/pr-review` |
+| Coarse do-issue parallelism | `do-issue` task planning |
+
+### Tools Evaluated
+
+| Tool | Model | Dependency | Status |
+|------|-------|------------|--------|
+| git --update-refs | Built-in (Git 2.38+) | Zero | GA |
+| gh pr create --base | gh CLI | Already required | GA |
+| jj (Jujutsu) | Local install, Git backend | Optional | Stable |
+| gh-stack (GitHub) | GitHub native | GitHub account | Private preview |
+| Graphite | Commercial SaaS | Vendor account | GA |
+| ghstack (Meta) | Python CLI | pip install | GA |
+| spr / stack-pr (Modular) | Python CLI | pip install | GA |
+
+**git --update-refs** (Git 2.38+) lets a single
+`git rebase --update-refs` call rewrite every branch
+in the stack atomically.
+Combined with `gh pr create --base <parent-branch>`,
+this covers the full stacked-PR submission loop with tools
+already present on any dev machine.
+
+**jj (Jujutsu)** is a Git-compatible VCS from Google.
+Its working copy is always a commit, descendants rebase
+automatically, and `jj split` / `jj squash` / `jj diffedit`
+reshape stacks interactively.
+It requires a local install but imposes no team-wide
+requirement: a developer with jj can operate alongside
+teammates using standard git.
+
+**gh-stack** (GitHub private preview) offers a stack map
+UI, cascading rebase after merge, and simultaneous multi-PR
+merge.
+It is not GA; adoption is premature.
+
+**Graphite** is the most feature-complete commercial
+offering but adds a vendor dependency.
+
+**ghstack** and **spr/stack-pr** each commit a Python CLI
+installation requirement for no benefit over the zero-dep
+foundation.
+
+## Decision
+
+Adopt **git --update-refs + gh pr create --base** as the
+zero-dependency foundation for stacked diff workflows.
+Layer **jj** as an optional accelerator when available.
+Defer gh-stack adoption until GA.
+
+### Foundation (Zero Dependency)
+
+Every stacked-diff skill uses this sequence:
+
+1. Create one branch per logical slice:
+   `git checkout -b stack/<name>/<slice>`.
+2. Commit changes on each slice branch.
+3. Run `git rebase --update-refs <base>` to update all
+   branch pointers after any rebase.
+4. Open PRs with explicit base targeting:
+   `gh pr create --base <parent-branch>`.
+5. After a PR merges, run `git rebase --update-refs master`
+   on the next branch to cascade the update down the stack.
+
+### Optional Accelerator (jj)
+
+When `jj --version` succeeds in the working directory:
+
+- Use `jj rebase -d <dest>` instead of
+  `git rebase --update-refs` for richer conflict UI.
+- Use `jj split` to split a commit into two stack slices
+  without interactive rebase.
+- Use `jj describe` to amend commit messages without
+  detaching HEAD.
+
+Detection is runtime, non-blocking:
+
+```bash
+if command -v jj &>/dev/null && jj root &>/dev/null; then
+  echo "jj available -- using jj accelerator"
+else
+  echo "jj not found -- using git --update-refs"
+fi
+```
+
+### Deferred
+
+- gh-stack: revisit when GA
+- Graphite: not adopted (vendor dependency)
+- ghstack / spr: not adopted (Python CLI dependency)
+
+### Implementation Phases
+
+| Phase | Scope |
+|-------|-------|
+| 1 | `stack-create` skill: initialize a stack from a multi-step plan |
+| 2 | `stack-push` skill: push all branches, open/update dependent PRs |
+| 3 | `stack-rebase` skill: cascading rebase after base PR merges |
+| 4 | Update `do-issue` task-planning module with stack awareness |
+| 5 | Update `/pr-review` to surface stack context |
+| 6 | Add gh-stack layer when GA |
+
+## Consequences
+
+### Positive
+
+- Zero new tool dependencies: git 2.38+ ships on macOS
+  12.3+ and all major Linux distros since 2023
+- gh CLI is already required by sanctum, so
+  `gh pr create --base` costs nothing to adopt
+- jj opt-in means early adopters get acceleration without
+  forcing team-wide migration
+- Skills are documentation-only markdown; they can be
+  updated independently of code changes
+- gh-stack integration is additive when it reaches GA
+
+### Negative
+
+- `git --update-refs` is manual: the developer must
+  remember to pass the flag; a forgotten rebase leaves
+  branches inconsistent
+- jj detection adds a shell exec on every stack operation
+  (negligible, but present)
+- gh-stack deferral means no automatic post-merge cascade
+  UI until it is GA
+
+### Risks
+
+- Git 2.38 may not be present on all CI runners
+  (mitigated: skills check `git version` and warn)
+- jj's Git backend compatibility is high but not 100%:
+  shallow clones and some submodule configs can fail
+  (mitigated: jj is optional, git is the fallback)
+
+## Related
+
+- ADR-0001: Plugin Dependency Isolation
+- Issue #405: Investigate stacked diff workflows
+- `plugins/sanctum/skills/stack-create/SKILL.md`
+- `plugins/sanctum/skills/stack-push/SKILL.md`
+- `plugins/sanctum/skills/stack-rebase/SKILL.md`
+- [git --update-refs docs](https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---update-refs)
+- [jj book](https://martinvonz.github.io/jj/latest/)
+- [gh-stack announcement](https://github.blog/changelog/2024-04-25-github-stacks-public-beta/)

--- a/plugins/egregore/scripts/notify.py
+++ b/plugins/egregore/scripts/notify.py
@@ -20,9 +20,11 @@ function without checking config itself.
 
 from __future__ import annotations
 
+import enum
 import importlib.util
 import logging
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -72,8 +74,6 @@ if _HERALD_AVAILABLE and _herald_mod is not None:
 # --- Stub fallbacks (when herald is absent) -------------------------
 
 else:
-    import enum
-    from dataclasses import dataclass
 
     class AlertEvent(enum.Enum):  # type: ignore[no-redef]  # conditional stub when herald absent
         """Stub alert events when herald is absent."""

--- a/plugins/gauntlet/hooks/precommit_gate.py
+++ b/plugins/gauntlet/hooks/precommit_gate.py
@@ -12,6 +12,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -213,8 +214,6 @@ def _graph_staleness_warning(
     Threshold is configurable via .gauntlet/config.json:
     {"stale_threshold_hours": 12}
     """
-    import time
-
     db_path = gauntlet_dir / "graph.db"
     if not db_path.exists():
         return None

--- a/plugins/sanctum/.claude-plugin/plugin.json
+++ b/plugins/sanctum/.claude-plugin/plugin.json
@@ -26,6 +26,9 @@
   "skills": [
     "./skills/commit-messages",
     "./skills/do-issue",
+    "./skills/stack-create",
+    "./skills/stack-push",
+    "./skills/stack-rebase",
     "./skills/doc-consolidation",
     "./skills/doc-updates",
     "./skills/file-analysis",

--- a/plugins/sanctum/openpackage.yml
+++ b/plugins/sanctum/openpackage.yml
@@ -39,6 +39,9 @@ skills:
 - skills/tutorial-updates
 - skills/update-readme
 - skills/version-updates
+- skills/stack-create
+- skills/stack-push
+- skills/stack-rebase
 - skills/workflow-improvement
 commands:
 - commands/commit-msg.md

--- a/plugins/sanctum/skills/stack-create/SKILL.md
+++ b/plugins/sanctum/skills/stack-create/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: stack-create
+description: 'Initialize a branch stack from a multi-step plan, creating one
+  branch per slice with correct parent-child relationships.'
+version: 1.0.0
+alwaysApply: false
+category: workflow-automation
+tags:
+- git
+- stacked-diffs
+- pr
+- branches
+- planning
+tools:
+- Bash
+- TodoWrite
+complexity: medium
+model_hint: standard
+estimated_tokens: 800
+dependencies:
+- sanctum:git-workspace-review
+- sanctum:do-issue
+---
+
+# Stack Create
+
+Initialize a stacked branch set from a multi-step plan.
+Each logical slice of the plan becomes one branch targeting
+the previous slice's branch as its base.
+
+## When to Use
+
+Use `stack-create` when a plan produces 2 or more ordered
+changes where each change depends on the previous one
+completing (and merging) before it can land.
+For independent changes, use parallel worktrees instead
+(see `egregore`).
+
+## Prerequisites
+
+- Git 2.38+ (`git version | awk '{print $3}'` to check)
+- `gh` CLI authenticated
+- A written plan with ordered slices (from `do-issue` or
+  `attune:blueprint`)
+- Clean working tree on the base branch (`git status`)
+
+## Required Progress Tracking
+
+Create `TodoWrite` items before starting:
+
+1. `stack-create:git-version-checked`
+2. `stack-create:slices-identified`
+3. `stack-create:branches-created`
+4. `stack-create:stack-verified`
+
+## Step 1: Verify Git Version (`git-version-checked`)
+
+```bash
+git version
+```
+
+Confirm the output is `2.38.0` or higher.
+If not, the `--update-refs` flag is unavailable.
+Warn the user and fall back to manual branch tracking.
+
+Check for optional jj accelerator:
+
+```bash
+if command -v jj &>/dev/null && jj root &>/dev/null 2>&1; then
+  echo "jj available"
+else
+  echo "using git --update-refs"
+fi
+```
+
+## Step 2: Identify Slices (`slices-identified`)
+
+Read the plan and extract ordered slices.
+Each slice must satisfy:
+
+- A single logical concern (one PR worth of change)
+- A clear dependency on the slice before it (if any)
+- A short name suitable for a branch suffix
+
+Example slices for a plan with three parts:
+
+```
+Slice 1: add-schema     -- database schema changes
+Slice 2: add-api        -- API layer (depends on schema)
+Slice 3: add-ui         -- frontend (depends on API)
+```
+
+Record the slice list before creating branches.
+
+## Step 3: Create Branches (`branches-created`)
+
+Starting from the base branch (usually `master` or `main`):
+
+```bash
+BASE=master
+STACK=stack/my-feature
+
+# Slice 1 branches from master
+git checkout -b ${STACK}/add-schema ${BASE}
+
+# Slice 2 branches from slice 1
+git checkout -b ${STACK}/add-api ${STACK}/add-schema
+
+# Slice 3 branches from slice 2
+git checkout -b ${STACK}/add-ui ${STACK}/add-api
+```
+
+Convention: `stack/<feature-name>/<slice-name>`
+
+Return to the first slice branch to begin work:
+
+```bash
+git checkout ${STACK}/add-schema
+```
+
+### jj Accelerator (if available)
+
+```bash
+# jj creates an empty commit on each branch automatically
+# Use jj new to move to a new change
+jj new -m "stack: add-schema" --no-edit
+```
+
+## Step 4: Verify Stack (`stack-verified`)
+
+Confirm the branch topology is correct:
+
+```bash
+git log --oneline --graph \
+  ${BASE}..${STACK}/add-ui
+```
+
+Each slice branch should appear as a linear chain above
+the base.
+
+If jj is available:
+
+```bash
+jj log --revisions \
+  "ancestors(${STACK}/add-ui, 10) & !ancestors(${BASE})"
+```
+
+## Notes
+
+- Never push branches until at least one commit exists on
+  each slice (empty branches produce confusing PRs)
+- The slice name in the branch becomes the PR title prefix
+  by convention; keep it short and descriptive
+- After creating the stack, proceed to `stack-push` to
+  open PRs, or work slice-by-slice and push when ready
+- If the plan changes, add or remove branches manually and
+  re-verify the topology in Step 4

--- a/plugins/sanctum/skills/stack-push/SKILL.md
+++ b/plugins/sanctum/skills/stack-push/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: stack-push
+description: 'Push all branches in a stack and create or update dependent PRs,
+  targeting each PR at its parent branch.'
+version: 1.0.0
+alwaysApply: false
+category: workflow-automation
+tags:
+- git
+- stacked-diffs
+- pr
+- push
+- github
+tools:
+- Bash
+- TodoWrite
+complexity: medium
+model_hint: standard
+estimated_tokens: 900
+dependencies:
+- sanctum:stack-create
+- sanctum:pr-prep
+- sanctum:git-workspace-review
+---
+
+# Stack Push
+
+Push all branches in a stack and open (or update) one PR
+per slice, with each PR targeting its parent branch as base.
+
+## When to Use
+
+Run `stack-push` after `stack-create` has initialized the
+branch topology and at least one commit exists on each
+slice branch.
+Also run it after adding commits to any slice to update
+open PRs.
+
+## Prerequisites
+
+- `stack-create` completed: branches exist with commits
+- `gh` CLI authenticated (`gh auth status`)
+- Each slice branch has at least one commit beyond its base
+
+## Required Progress Tracking
+
+Create `TodoWrite` items before starting:
+
+1. `stack-push:branches-listed`
+2. `stack-push:branches-pushed`
+3. `stack-push:prs-opened`
+4. `stack-push:stack-summary-posted`
+
+## Step 1: List Stack Branches (`branches-listed`)
+
+Identify all branches in the stack.
+By convention they share a `stack/<feature-name>/` prefix:
+
+```bash
+STACK=stack/my-feature
+BASE=master
+
+git branch --list "${STACK}/*" | sed 's/^[* ]*//'
+```
+
+Verify each branch has commits beyond the base:
+
+```bash
+for branch in $(git branch --list "${STACK}/*" \
+    | sed 's/^[* ]*//'); do
+  count=$(git rev-list --count \
+    "$(git merge-base ${BASE} ${branch})..${branch}")
+  echo "${branch}: ${count} commit(s)"
+done
+```
+
+Any branch showing `0 commits` must have work added before
+pushing.
+
+## Step 2: Push Branches (`branches-pushed`)
+
+Push every slice branch to the remote in stack order
+(base slice first):
+
+```bash
+for branch in $(git branch --list "${STACK}/*" \
+    | sed 's/^[* ]*//' | sort); do
+  git push --set-upstream origin "${branch}"
+  echo "pushed: ${branch}"
+done
+```
+
+### jj Accelerator (if available)
+
+```bash
+jj git push --all
+```
+
+## Step 3: Open or Update PRs (`prs-opened`)
+
+Create one PR per slice, targeting its parent branch.
+For the first slice the parent is `master`; for subsequent
+slices the parent is the previous slice's branch.
+
+```bash
+PREV_BASE=master
+
+for branch in $(git branch --list "${STACK}/*" \
+    | sed 's/^[* ]*//' | sort); do
+
+  # Check if a PR already exists for this branch
+  existing=$(gh pr list \
+    --head "${branch}" \
+    --json number \
+    --jq '.[0].number' 2>/dev/null)
+
+  if [ -n "${existing}" ]; then
+    echo "PR #${existing} already open for ${branch} -- skipping"
+  else
+    gh pr create \
+      --base "${PREV_BASE}" \
+      --head "${branch}" \
+      --title "[$(echo ${branch} | sed 's|.*/||')] <title>" \
+      --body "Part of stack \`${STACK}\`." \
+      --draft
+    echo "opened PR for ${branch} (base: ${PREV_BASE})"
+  fi
+
+  PREV_BASE="${branch}"
+done
+```
+
+Fill in the actual PR titles and bodies before removing
+the `--draft` flag.
+Run `Skill(sanctum:pr-prep)` on each slice to generate
+quality-gated descriptions.
+
+## Step 4: Post Stack Summary (`stack-summary-posted`)
+
+After all PRs are open, post a summary comment on the
+first PR (the root of the stack) listing the full chain:
+
+```bash
+ROOT_PR=$(gh pr list \
+  --head "${STACK}/$(git branch --list \
+    "${STACK}/*" | sed 's/^[* ]*//' | sort | head -1 \
+    | sed 's|.*/||')" \
+  --json number --jq '.[0].number')
+
+# Build the stack table
+BODY="## Stack\n\n| # | Branch | PR |\n|---|--------|----|\n"
+N=1
+for branch in $(git branch --list "${STACK}/*" \
+    | sed 's/^[* ]*//' | sort); do
+  pr_num=$(gh pr list --head "${branch}" \
+    --json number --jq '.[0].number')
+  BODY="${BODY}| ${N} | \`${branch}\` | #${pr_num} |\n"
+  N=$((N+1))
+done
+
+gh pr comment "${ROOT_PR}" --body "$(printf "${BODY}")"
+```
+
+## Notes
+
+- Always push in stack order so GitHub sees the parent
+  branch before the child PR is opened
+- Use `--draft` by default; promote slices to ready
+  individually as they pass review
+- After any `git rebase --update-refs` run, re-push with
+  `git push --force-with-lease` (never `--force`)
+- When a base PR merges, run `Skill(sanctum:stack-rebase)`
+  to cascade the rebase before updating the next PR's base

--- a/plugins/sanctum/skills/stack-rebase/SKILL.md
+++ b/plugins/sanctum/skills/stack-rebase/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: stack-rebase
+description: 'Cascading rebase for a PR stack after a base PR merges or its base
+  branch changes, using git --update-refs to rewrite all descendant branches atomically.'
+version: 1.0.0
+alwaysApply: false
+category: workflow-automation
+tags:
+- git
+- stacked-diffs
+- rebase
+- pr
+- cascade
+tools:
+- Bash
+- TodoWrite
+complexity: medium
+model_hint: standard
+estimated_tokens: 900
+dependencies:
+- sanctum:stack-create
+- sanctum:stack-push
+- sanctum:git-workspace-review
+---
+
+# Stack Rebase
+
+Cascade a rebase through an entire PR stack after a base
+PR merges or the upstream base branch changes.
+
+## When to Use
+
+Run `stack-rebase` in any of these situations:
+
+- The first PR in the stack merged into `master`; the
+  second PR now needs to target `master` directly
+- `master` has moved forward and stack branches need to
+  incorporate the new commits
+- A mid-stack PR was revised and descendants need to
+  pick up the change
+
+## Prerequisites
+
+- All slice branches exist locally (`git branch --list`)
+- Remote is up to date (`git fetch origin`)
+- Working tree is clean (`git status`)
+- Git 2.38+ for `--update-refs`
+
+## Required Progress Tracking
+
+Create `TodoWrite` items before starting:
+
+1. `stack-rebase:fetch-complete`
+2. `stack-rebase:trigger-identified`
+3. `stack-rebase:rebase-complete`
+4. `stack-rebase:conflicts-resolved`
+5. `stack-rebase:force-pushed`
+6. `stack-rebase:prs-updated`
+
+## Step 1: Fetch Remote State (`fetch-complete`)
+
+```bash
+git fetch origin
+```
+
+If the merged PR's branch still exists on remote, note
+that GitHub retains the branch after merge.
+The merged branch itself is no longer a valid stack base.
+
+## Step 2: Identify the Trigger (`trigger-identified`)
+
+Determine what changed:
+
+**Case A — Base PR merged into master:**
+The slice that was the old "root" is now in `master`.
+All remaining slices need to rebase onto `master`.
+
+```bash
+# Confirm the merged branch is now in master
+git branch -r --merged origin/master | grep "${MERGED_BRANCH}"
+```
+
+**Case B — Master moved forward:**
+Slices are behind `master` but the stack topology is
+unchanged.
+Rebase the root slice onto `master`; `--update-refs`
+carries all descendants.
+
+**Case C — Mid-stack revision:**
+A slice was amended.
+All descendant slices need to rebase onto it.
+
+## Step 3: Run the Cascading Rebase (`rebase-complete`)
+
+### Case A and B: Rebase root slice onto master
+
+```bash
+STACK=stack/my-feature
+BASE=master
+
+# Check out the root slice
+ROOT_SLICE=$(git branch --list "${STACK}/*" \
+  | sed 's/^[* ]*//' | sort | head -1)
+
+git checkout "${ROOT_SLICE}"
+
+# Rebase with --update-refs rewrites all stack branches
+git rebase --update-refs origin/${BASE}
+```
+
+`--update-refs` scans the reflog and updates every local
+branch ref that points to a commit being rebased.
+All slice branches in the stack are rewritten in one pass.
+
+### Case C: Rebase from a mid-stack slice
+
+```bash
+# Check out the first slice BELOW the amended one
+CHILD_SLICE=stack/my-feature/add-api  # example
+
+git checkout "${CHILD_SLICE}"
+git rebase --update-refs stack/my-feature/add-schema
+```
+
+### jj Accelerator (if available)
+
+```bash
+# jj rebases all descendants automatically on any change
+# To rebase the whole stack onto master:
+jj rebase -d master \
+  -r "ancestors(${STACK}/add-ui) & !ancestors(master)"
+```
+
+## Step 4: Resolve Conflicts (`conflicts-resolved`)
+
+If the rebase pauses with conflicts:
+
+```bash
+# See which file conflicts
+git status
+
+# After resolving each file:
+git add <resolved-file>
+git rebase --continue
+```
+
+Repeat until the rebase completes.
+If a conflict is too complex, abort and investigate:
+
+```bash
+git rebase --abort
+```
+
+Then examine the diff between the conflicting commits
+before retrying.
+
+## Step 5: Force-Push Updated Branches (`force-pushed`)
+
+After a successful rebase, push all slice branches.
+Use `--force-with-lease` to guard against remote changes
+made since the last fetch:
+
+```bash
+for branch in $(git branch --list "${STACK}/*" \
+    | sed 's/^[* ]*//' | sort); do
+  git push --force-with-lease origin "${branch}"
+  echo "force-pushed: ${branch}"
+done
+```
+
+Never use `--force` (drops the remote-change guard).
+
+### jj Accelerator (if available)
+
+```bash
+jj git push --all --allow-new
+```
+
+## Step 6: Update PR Bases (`prs-updated`)
+
+**Case A only**: After the root slice merged and you
+rebased remaining slices onto `master`, the next PR in
+the stack now targets the wrong base.
+Update its base via the GitHub CLI:
+
+```bash
+NEXT_PR=456   # PR number of the new stack root
+
+gh pr edit "${NEXT_PR}" --base master
+```
+
+For PRs further down the stack, their bases remain the
+previous slice branch, which `--update-refs` already
+rewrote; no base edit is needed for them.
+
+Verify the full stack is consistent:
+
+```bash
+for branch in $(git branch --list "${STACK}/*" \
+    | sed 's/^[* ]*//' | sort); do
+  pr_num=$(gh pr list --head "${branch}" \
+    --json number,baseRefName \
+    --jq '.[0] | "#\(.number) base=\(.baseRefName)"')
+  echo "${branch}: ${pr_num}"
+done
+```
+
+## Conflict Prevention Tips
+
+- Keep slices small: the smaller each PR, the less surface
+  area for conflicts during rebase
+- Rebase frequently: rebasing onto a freshly merged master
+  once a day is cheaper than resolving a week of drift
+- Avoid amending commits that are already under review;
+  prefer a fixup commit and squash at merge time
+
+## Notes
+
+- `git rebase --update-refs` requires Git 2.38+; confirm
+  with `git version` before running
+- If `--update-refs` is unavailable, manually check out
+  and rebase each slice branch in order from root to tip
+- After force-pushing, GitHub automatically marks PR
+  reviews as stale; remind reviewers to re-approve
+- The `stack-push` skill documents how to re-post the
+  stack summary comment after a rebase changes PR SHAs


### PR DESCRIPTION
## Summary

- Adds **ADR-0010** (`docs/adr/0010-stacked-diff-workflows.md`) documenting the decision to adopt `git --update-refs` + `gh pr create --base` as the zero-dependency foundation for stacked diff workflows, with jj as an optional accelerator and gh-stack deferred until GA
- Creates three skeleton sanctum skills for stacked diff operations:
  - `stack-create`: initialize a branch stack from a multi-step plan
  - `stack-push`: push all stack branches and open or update dependent PRs with correct base targeting
  - `stack-rebase`: cascading rebase after a base PR merges, using `git rebase --update-refs` atomically
- Registers all three skills in `openpackage.yml`, `.claude-plugin/plugin.json`, and the capabilities reference

## Context

Sanctum's current workflows (`/prepare-pr`, `/commit-msg`, `/acp`) assume linear branches. Egregore parallel worktrees are independent with no dependency chains. As do-issue plans increasingly produce interdependent changes, agents need stacked PR support.

The ADR documents tooling evaluated (gh-stack, jj, Graphite, ghstack, spr, git built-in), the rationale for choosing the zero-dependency foundation, and a 6-phase implementation roadmap.

## Test plan

- [ ] Verify all three `SKILL.md` files render correctly in the book
- [ ] Confirm `sanctum:stack-create`, `sanctum:stack-push`, `sanctum:stack-rebase` appear in skill listings
- [ ] Review ADR for accuracy against the research findings in issue #405
- [ ] All pre-commit hooks pass (verified locally before push)

Fixes #405