### PR TITLE
fix(abstract): skip null duration_ms in skill log aggregation

### DIFF
--- a/plugins/abstract/scripts/aggregate_skill_logs.py
+++ b/plugins/abstract/scripts/aggregate_skill_logs.py
@@ -198,7 +198,7 @@ def calculate_skill_metrics(
     partial_count = outcome_counts["partial"]
 
     # Duration stats
-    durations = [e["duration_ms"] for e in entries if "duration_ms" in e]
+    durations = [e["duration_ms"] for e in entries if e.get("duration_ms") is not None]
     avg_duration = statistics.mean(durations) if durations else 0.0
     max_duration = max(durations) if durations else 0
 


### PR DESCRIPTION
## Symptom

`aggregate_skill_logs.py`'s `calculate_skill_metrics()` freezes with a `TypeError` for any skill whose logs include a slash-invoked entry.

## Cause

```python
durations = [e["duration_ms"] for e in entries if "duration_ms" in e]
```

The skill-log writer emits `"duration_ms": null` for slash-invoked entries. `"duration_ms" in e` is `True` even when the value is `None` (the key is present), so `None` ends up in `durations`. `statistics.mean(durations)` then raises:

```
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
```

which halts aggregation for that skill entirely.

## Fix

One-line change, filter on the value instead of key presence:

```python
durations = [e["duration_ms"] for e in entries if e.get("duration_ms") is not None]
```

`max(durations)` a couple of lines below draws from the same filtered list, so it's covered by the same fix — no separate change needed there.

## Verification

- All 66 existing tests in `plugins/abstract/tests/scripts/test_aggregate_skill_logs.py` pass unchanged.
- Manually reproduced: calling `calculate_skill_metrics()` with a mix of `duration_ms: 1200` and `duration_ms: None` entries now returns correct `avg_duration_ms`/`max_duration_ms` instead of raising.
