### PR TITLE
feat(tome): graph-backed research engine with metrics harness

### DIFF
--- a/docs/tome-research-engine/design-spec.md
+++ b/docs/tome-research-engine/design-spec.md
@@ -1,0 +1,155 @@
+# Tome Research Engine: Design Specification
+
+**Date**: 2026-07-17
+**Companion to**: `research-report.md`, `metrics-framework.md`
+**Status**: Draft for plan-review + war-room gate before build
+
+## Thesis
+
+Turn tome from a flat-list aggregator into a graph-backed research
+engine by **reusing the graph, embedding, and decay tooling that
+already exists in `memory-palace`, and by keeping the ground-truth
+citation edges tome already fetches and discards.** No new graph
+database, no LLM-based graph construction, no heavy ML in the hot path.
+
+## The graph decision: reuse, not build
+
+The single largest design choice is where the knowledge graph lives.
+The evidence resolves it.
+
+| Option | For | Against | Verdict |
+|--------|-----|---------|---------|
+| **Reuse `memory-palace` `KnowledgeGraph`** | Entities + temporal triples + weighted synapses already exist; `PalaceGraphAnalyzer` already gives PageRank, community detection, and Adamic-Adar link prediction; `tome:export` already targets memory-palace; zero new graph code | Cross-plugin coupling; tome gains a dependency on memory-palace internals | **Chosen** |
+| Build tome-native graph | No cross-plugin coupling | Reinvents a working SQLite triple/synapse store; violates additive-bias-defense and shared-utility rules; more surface to maintain | Rejected |
+| LLM-constructed graph (GraphRAG-style) | Richest entity/relation extraction | The #1 reported failure mode: hallucinated entities corrupt the graph "cyclically"; expensive indexing | Rejected for construction; the community/summary *ideas* are still adopted |
+
+**Coupling containment.** Tome talks to memory-palace through a single
+thin adapter module (`tome/graph/palace_adapter.py`), not scattered
+imports, so the coupling is one seam that can be swapped or mocked. Two
+amendments from the war-room review (`docs/plans/2026-07-17-war-room-tome-graph-decision.md`):
+
+1. memory-palace must promote `KnowledgeGraph` and `PalaceGraphAnalyzer`
+   into its public `__all__` so tome consumes a supported API, not
+   internals; a tome CI contract test pins that surface.
+2. memory-palace is a **declared dependency** of tome's graph feature,
+   not a runtime silent no-op. Absence is an install-time invariant; if
+   ever genuinely absent, tome surfaces an explicit
+   capability-unavailable signal. Base (non-graph) research is
+   unaffected because the graph layer is additive.
+
+## Architecture
+
+```
+arXiv / S2 / OpenAlex          existing channels (academic.py)
+        |
+        v
+  [ ingest ]  thin API clients (arxiv.py / pyalex / semanticscholar)
+        |     + optional GROBID sidecar for full text
+        v
+  Paper model  sections + references + citation edges   <-- NEW, edges KEPT
+        |
+        v
+  [ palace_adapter ]  write entities + triples + synapses  <-- reuse KnowledgeGraph
+        |
+        +--> detect_communities   -> "common threads"      <-- reuse graph_analyzer
+        +--> predict_links (A-A)   -> "further research paths"
+        +--> pagerank/betweenness  -> impact centrality
+        |
+        v
+  [ retrieval ]  EmbeddingIndex (hash fallback) + on-condition graph escalation
+        |
+        v
+  [ metrics harness ]  five-dimension vector + RQI, persisted   <-- NEW
+        |
+        v
+  report / export (existing output layer, now graph-aware)
+```
+
+## Reused memory-palace interfaces
+
+The build calls these existing APIs (no reimplementation):
+
+- `KnowledgeGraph.upsert_entity` / `bulk_upsert_entities` (papers,
+  authors, concepts as nodes)
+- `KnowledgeGraph.add_triple` (citation and authorship edges as
+  temporal triples)
+- `KnowledgeGraph.create_synapse` / `strengthen_synapse` (weighted
+  co-citation / co-read associations that decay)
+- `PalaceGraphAnalyzer.pagerank`, `detect_communities`,
+  `find_bridges`, `find_keystones`, `predict_links`
+- `corpus.embedding_index.EmbeddingIndex` (semantic retrieval, hash
+  fallback so no hard dependency)
+- `corpus.semantic_deduplicator.SemanticDeduplicator` (near-duplicate
+  removal across arXiv/S2/OpenAlex)
+- `corpus.decay_model` (importance half-lives for pruning)
+
+## Changes inside tome
+
+| Area | Change | Reuses / basis |
+|------|--------|----------------|
+| `models.py` | Add `Paper` (sections, references, citation edges) alongside `Finding` | new; ceremony justified by the citation-edge need |
+| `channels/academic.py` | Stop discarding citation-chain edges; populate `Paper.references`; optional GROBID full-text | wire-up (`academic.py:520`) |
+| `synthesis/ranker.py` | Fold `compute_triangulation_bonus` into the ranked score | wire-up (`ranker.py:27`) |
+| `synthesis/quality.py` | Upgrade `identify_gaps` to emit next-query suggestions (sub-question closure) | wire-up (`quality.py:19`) |
+| `graph/palace_adapter.py` | New thin seam to memory-palace; no-op if absent | reuse |
+| `graph/threads.py` | `detect_communities` -> threads; `predict_links` -> paths, with exploit/explore split + saturation stop | reuse |
+| `retrieval/` | `EmbeddingIndex` semantic search; on-condition graph escalation for multi-hop queries | reuse |
+| `metrics/` | Five-dimension harness + RQI + persistence; `make metrics` | new |
+| `output/export.py` | Emit graph entities/edges, not only markdown | wire-up (`export.py:9`) |
+| `README.md` | Fix the "parses PDFs" claim to match reality | doc fix |
+
+## Dependency policy
+
+- **Hard deps stay minimal.** Core spine is `networkx` (already a
+  memory-palace dependency), plus thin `requests`-only API clients
+  (`arxiv`, `pyalex`, `semanticscholar`). Metrics use a hand-rolled
+  nDCG or `pytrec_eval`; no LLM required for the headline numbers.
+- **Heavy tier is optional and isolated.** GROBID runs as a Docker
+  sidecar behind an HTTP client; `sentence-transformers` / `faiss`
+  stay optional extras (the hash-vector fallback covers the default);
+  `microsoft/graphrag` and PyTorch Geometric are out of scope for v1.
+- **Supply-chain gates.** OpenAlex needs an API key (Feb 2026);
+  Nougat's weights are CC-BY-NC (excluded); every new dependency runs
+  through `leyline:supply-chain-advisory`.
+
+## Build increments (each a TDD slice, own PR)
+
+1. **Keep the edges.** `Paper` model + citation-edge capture in
+   `academic.py`; unit tests assert edges survive parsing. No graph
+   write yet.
+2. **Graph seam.** Promote `KnowledgeGraph` / `PalaceGraphAnalyzer` to
+   memory-palace's public `__all__`; `palace_adapter` writes
+   papers/edges into `KnowledgeGraph`; CI contract test pins the
+   public surface; explicit capability gate (not silent no-op) when
+   the feature is disabled.
+3. **Threads and paths.** `detect_communities` + `predict_links`
+   wired; triangulation bonus folded into rank; `identify_gaps`
+   suggests next queries.
+4. **Semantic retrieval.** `EmbeddingIndex` search + on-condition graph
+   escalation; `SemanticDeduplicator` for near-dups.
+5. **Metrics harness.** Five-dimension vector + RQI, persisted; gold-set
+   fixture; `make metrics`; README fix.
+
+Increments 1 to 3 carry most of the value (the graph the user asked
+for) at the least new code. Increment 4 to 5 are tunable in depth.
+
+## Non-goals (v1)
+
+- LLM-based entity/relation graph construction (rejected: hallucination
+  risk).
+- A bundled vector database or GPU parser (optional extras only).
+- A single collapsed "research value" score (the metrics framework
+  forbids it).
+
+## Exit criteria
+
+- [ ] The graph decision is recorded with tradeoffs and passes the
+      war-room gate before any build.
+- [ ] `palace_adapter` is the only module importing memory-palace
+      internals (one swappable seam).
+- [ ] Base (non-graph) research runs unchanged; the graph feature is
+      gated by an explicit capability check, not a silent fallback, and
+      memory-palace's graph API is public and contract-tested.
+- [ ] Each build increment lands as its own reviewable PR on a fresh
+      branch, not on the current RED-zone branch.
+- [ ] No new hard dependency ships without a supply-chain-advisory note.

--- a/docs/tome-research-engine/metrics-framework.md
+++ b/docs/tome-research-engine/metrics-framework.md
@@ -1,0 +1,158 @@
+# Tome Research-Quality Metrics Framework
+
+**Date**: 2026-07-17
+**Companion to**: `research-report.md`, `design-spec.md`
+
+## Thesis
+
+Measure research quality as a **five-dimension vector, not a single
+score.** The research is unambiguous that collapsing citation-derived
+signals into one number is how bibliometrics went wrong (the disruption
+index is biased and gameable). Each dimension gets deterministic,
+inspectable proxies grounded in signals tome already computes or in
+tooling that already exists in this repo. LLM-judged signals are
+included only where structural proxies cannot reach, and always
+labeled as directional.
+
+Legend for the "status" column below:
+
+- **exists**: already computed in tome today
+- **wire-up**: computed but dormant, or present in `memory-palace` and
+  callable
+- **new**: requires new code
+
+## Dimension 1: Relevancy
+
+How on-topic and authoritative the retrieved set is. This is the one
+dimension tome measures today, and the one with the most trustworthy
+external metrics.
+
+| Metric | Formula / source | Status |
+|--------|------------------|--------|
+| nDCG@k, MRR, recall@k | standard IR, vs. a labeled gold set | new (harness) |
+| Adjusted relevance | `compute_relevance_score` (relevance + authority + recency) | exists (`ranker.py:68`) |
+| Triangulation-weighted relevance | fold dormant `compute_triangulation_bonus` into the rank | wire-up (`ranker.py:27`) |
+| Query-embedding cosine | `EmbeddingIndex` cosine(finding, query) | wire-up (memory-palace) |
+| Faithfulness (optional) | RAGAS-style claim grounding | new, optional, labeled |
+
+**Guardrail.** nDCG/MRR/recall against hand-labeled relevance are the
+headline. The 0.55 human correlation of LLM-judge metrics keeps
+faithfulness a secondary, opt-in signal.
+
+## Dimension 2: Insight
+
+Depth beyond the abstract, and whether synthesized claims are grounded.
+Tome scores 0 here today because ingestion is abstract-only.
+
+| Metric | Formula / source | Status |
+|--------|------------------|--------|
+| Section-coverage ratio | ingested sections / total sections per paper | new (paper model) |
+| Citation-supported claim ratio | claims with a backing citation edge / total claims | new |
+| Sub-question closure | answered planned sub-questions / total | wire-up (upgrade `identify_gaps`) |
+| Full-text depth flag | abstract-only vs. full-text ingested | new |
+
+**Guardrail.** Prefer the structural claim-support ratio (deterministic,
+uses the citation graph) over an LLM faithfulness judge for the headline
+insight number.
+
+## Dimension 3: Creativity
+
+Novelty, diversity, and non-obvious cross-domain connection. The trap
+here is rewarding noise: a random retriever scores high on novelty and
+is useless. Every creativity metric is therefore paired with relevance.
+
+| Metric | Formula / source | Status |
+|--------|------------------|--------|
+| Source/domain diversity | `1 - Herfindahl` over channels | exists (`quality.py:96`) |
+| TRIZ bridge count | cross-domain analogies found | exists (triz channel) |
+| Corpus novelty | mean embedding distance of new findings from the prior-session corpus | wire-up (`EmbeddingIndex` + `memory.py`) |
+| Reference atypicality | z-scored reference co-occurrence (Uzzi 2013) | new (needs references) |
+| Link-prediction surprise | `predict_links` (Adamic-Adar) edges bridging distant communities | wire-up (`graph_analyzer.py:153`) |
+
+**Guardrail.** Score novelty only jointly with relevance (a bandit
+exploit/explore split), and apply an exploration-saturation stop so
+speculative "further research paths" stay bounded, not a flood.
+
+## Dimension 4: Performance
+
+Speed, cost, and efficiency of the pipeline. Cheapest to measure, and
+the dimension the tiered/on-condition design most directly moves.
+
+| Metric | Formula / source | Status |
+|--------|------------------|--------|
+| Wall-clock per session | timer around the research run | new (timers) |
+| Token budget adherence | tokens spent vs. `research_planner` tier (2000/4000/6000/8000) | exists (`research_planner.py:22`) |
+| Findings per 1k tokens | unique findings / tokens | new |
+| Dedup ratio | removed / total pre-dedup | exists (`merger.py`) |
+| Graph-escalation rate | fraction of queries that hit the expensive graph path | new |
+| Retrieval latency p50/p95 | per-query timing | new |
+
+**Guardrail.** Report cost-per-quality (tokens per unit nDCG gain), not
+raw speed, so a fast-but-useless run does not look good.
+
+## Dimension 5: Impact
+
+Downstream influence and structural importance. Powerful and cheap to
+compute from the graph, but the most bias-prone. Normalization is
+mandatory, not optional.
+
+| Metric | Formula / source | Status |
+|--------|------------------|--------|
+| Graph centrality | PageRank / betweenness | wire-up (`graph_analyzer.py:51`) |
+| Citation count | from `metadata` (Semantic Scholar / OpenAlex) | exists |
+| Disruption (CD) index | Funk and Owen-Smith 2017, **field- and cohort-normalized, fixed window** | new (guarded) |
+| Bridge / keystone finding | `find_bridges` / `find_keystones` | wire-up (`graph_analyzer.py:96`) |
+| Cross-session reuse rate | times a finding is re-imported across sessions | exists (`memory.py:61`) |
+| Decay-adjusted importance | `decay_model` half-life weighting | wire-up (`decay_model.py`) |
+
+**Guardrail (evidence-backed, non-negotiable).** The disruption index is
+biased by citation inflation, depends on the chosen citation-window
+length, and barely overlaps with other novelty constructs. So: compare
+only within field and publication-year cohort; fix and disclose the
+citation window; never present a single collapsed "impact" number.
+
+## Composite index
+
+Report the five dimensions as a **radar/vector dashboard**. A scalar
+Research Quality Index is offered only as a transparent, reweightable
+convenience:
+
+```
+RQI = w_rel * Relevancy + w_ins * Insight + w_cre * Creativity
+    + w_perf * Performance + w_imp * Impact
+```
+
+Default weights emphasize the trustworthy dimensions
+(`w_rel = w_ins = 0.25`, `w_cre = w_imp = 0.2`, `w_perf = 0.1`), are
+config-exposed, and every component score is stored alongside the
+scalar so the vector is always recoverable. This mirrors tome's
+existing `compute_quality_score` blend but widens it from three terms
+to five.
+
+## Benchmark and instrumentation
+
+- **Gold set.** A fixed panel of arXiv topics with hand-labeled
+  relevant papers (seeded from BEIR SciFact/SciDocs plus a small
+  in-repo set), committed under `tests/fixtures/`, so nDCG/MRR/recall
+  are reproducible offline with no network and no LLM.
+- **Before/after protocol.** Run the same topics through the current
+  pipeline and the upgraded one; report the per-dimension delta. A
+  metric that does not move on the benchmark does not justify its code.
+- **Persistence.** Computed scores are ephemeral today (recomputed each
+  run, never stored). Persist them on `Finding.metadata` and in the
+  session record so trends are measurable across runs. This is a
+  prerequisite for measuring impact (cross-session reuse) at all.
+- **Make target.** `make metrics` runs the harness on the gold set and
+  prints the five-dimension table plus the RQI.
+
+## Exit criteria
+
+- [ ] Each of the five dimensions has at least one deterministic
+      (non-LLM) proxy that runs offline on the gold set.
+- [ ] `make metrics` prints the five-dimension table and RQI for a
+      committed fixture with no network access.
+- [ ] Impact metrics refuse to emit a cross-cohort comparison (field +
+      year normalization enforced in code, not just documented).
+- [ ] Every LLM-judge metric is labeled directional and is opt-in.
+- [ ] Computed scores persist across sessions (reuse rate is non-zero
+      on a second run over overlapping topics).

--- a/docs/tome-research-engine/research-report.md
+++ b/docs/tome-research-engine/research-report.md
@@ -1,0 +1,255 @@
+# Tome Research Engine: Deep-Research Report
+
+**Date**: 2026-07-17
+**Method**: Dogfooded `tome` across four channels (academic, code,
+discourse, TRIZ) over four tracks (GraphRAG/KG construction, retrieval
+and RAG evaluation, scientific full-text ingestion, novelty/impact
+measurement). Saturation reached after one round: the load-bearing
+findings cross-validated across independent channels, so no `dig`
+rounds were run (per the exploration-saturation stop rule the research
+itself surfaced).
+
+## Thesis
+
+Tome should become best-in-class not by ingesting more, but by
+**keeping the citation edges it already discards, linking them into
+the knowledge graph that already exists in `memory-palace`, and
+serving the graph only when a query needs it.** The external evidence
+converges on three disciplines: build a real entity/citation graph
+(GraphRAG), but escalate to it on condition, not always; measure
+retrieval with deterministic labeled metrics (nDCG/MRR) and treat
+LLM-judge scores as directional only; and compute impact/novelty from
+graph structure while normalizing away the well-documented biases that
+make raw citation metrics misleading. Every heavy dependency (LLM
+graph construction, GPU parsers, vector frameworks) is optional and
+isolated. The minimal-dependency spine (`networkx`, thin API clients,
+a hand-rolled nDCG) already covers the core.
+
+## Track 1: GraphRAG and knowledge-graph construction
+
+**The reference architecture is settled.** Microsoft GraphRAG
+([2404.16130][gr]) is the canonical pattern: an LLM extracts an
+entity/relation graph, Leiden community detection partitions it, and
+community summaries answer global queries. LightRAG
+([2410.05779][lr]) adds incremental graph updates (no full re-index
+when new papers arrive, which fits a growing arXiv corpus). HippoRAG
+([2405.14831][hr], NeurIPS 2024) runs Personalized PageRank seeded by
+query entities for single-shot multi-hop retrieval.
+
+**But graph structure is not always worth its cost.** Two 2025
+studies isolate where it helps: GraphRAG-Bench ([2506.02404][grb]) and
+"When to use Graphs in RAG" ([2506.05690][wtg]) find the graph wins on
+multi-hop and complex reasoning, and adds overhead with little gain on
+simple fact lookups. Practitioners confirm this bluntly: an HN thread
+([KAG][kag], 230 pts) calls graph RAG "incrementally" better, not
+transformational, and warns that LLM-based graph construction
+hallucinates entities and "cyclically" corrupts the graph.
+
+**The historical dealbreaker was cost, and it collapsed.** Indexing a
+5GB corpus fell from roughly $33,000 in early 2024 to roughly $33 by
+mid-2025 (about 1000x), driven by model price cuts and LazyGraphRAG
+deferring summarization to query time ([Cost Cliff][cc];
+[TianPan][tp]). One reported 4M-doc deployment paid about 1.6x infra
+for citation accuracy 87 to 96 percent and multi-hop correctness 41 to
+78 percent ([TianPan][tp]). The objection to re-evaluate on today is
+accuracy, not 2024 cost lore.
+
+**Implication for tome.** Tome already fetches Semantic Scholar
+references and citations, then throws the edges away. Keeping those
+edges is a graph built from ground-truth citation data, not from
+error-prone LLM extraction. That sidesteps the single biggest reported
+failure mode (hallucinated graph construction) while capturing most of
+the multi-hop value. Serve the graph on condition (multi-hop queries),
+not on every lookup.
+
+## Track 2: Retrieval and RAG evaluation
+
+**Two metric families, with a clear trust ordering.** Deterministic,
+label-based IR metrics (nDCG@k, MRR, MAP, recall@k) are the trustworthy
+yardstick; BEIR ([2104.08663][beir]) standardizes nDCG@10 and includes
+the scientific subsets SciFact and SciDocs, the closest public proxy
+for tome. TREC Deep Learning ([2003.07820][trec]) defines the metric
+protocols. LLM-judged, reference-free metrics (RAGAS
+[2309.15217][ragas]; ARES [2311.09476][ares], which adds
+prediction-powered confidence intervals) measure faithfulness and
+answer/context relevance without gold labels, but at a cost to trust.
+
+**LLM-judge scores are directional, not ground truth.** RAGAS
+correlates with human judgment at only about 0.55 harmonic mean
+([getmaxim][gm]), and the CALM framework catalogs 12 distinct judge
+biases (position, verbosity, self-enhancement, authority)
+([Evidently][ev]). The deeper problem, from practitioners: "correct
+context does not equal correct answer" ([HN][rag-ready]), so retrieval
+success does not imply answer correctness.
+
+**Implication for tome.** Anchor the metrics harness on deterministic
+nDCG/MRR/recall against a small hand-labeled arXiv gold set (tome
+already knows the query and the returned findings). Offer LLM-judge
+faithfulness as an optional, clearly-labeled signal to guard against
+hallucinated citations in synthesized answers, never as the headline
+score.
+
+## Track 3: Scientific full-text ingestion
+
+**GROBID and Nougat are complementary, not competing.** GROBID
+([kermitt2/grobid][grobid]) parses PDFs to TEI XML with header
+metadata, sections, and structured references; it is fast (about 10
+PDFs/sec, roughly 400x Nougat) and leads reference extraction (F1
+about 0.79 to 0.90 with the deep-learning citation model)
+([Meuschke 2023][meu]). Nougat ([2308.13418][nougat], ICLR 2024) is a
+visual-transformer OCR that preserves math and tables GROBID's
+text-layer approach loses, but it is slow and, by its authors' own
+disclosure, "skips or hallucinates" reference numbers in
+bibliographies. The robust real-world pattern is hybrid: one tool
+primary, the other as fallback (reported splits near 94/6), with
+cheap PyMuPDF for clean layouts and an ML parser only for math-heavy
+pages ([2410.09871][pdfcmp]). Tables and dense numeric data are where
+every tool breaks ([CodeCut][cc2]).
+
+**A pre-built corpus removes most of the parsing burden.** unarXive
+2022 ([2303.14957][unarxive], JCDL 2023) ships 1.9M arXiv papers with
+structured full text and a resolved in-text citation network; S2ORC
+([1911.02782][s2orc], ACL 2020) offers 81M papers with inline citation
+spans. Tome can bootstrap its citation graph from these instead of
+parsing every PDF.
+
+**Implication for tome.** The README claim that tome "parses PDFs" is
+aspirational: parsing is deferred to the LLM via markitdown and
+captured in no data model. The honest, low-cost path is a structured
+paper model (sections plus references) fed by thin API metadata
+(arxiv.py, pyalex, semanticscholar) plus optional GROBID as a sidecar
+for real full-text extraction. Fix the README to match.
+
+## Track 4: Novelty, insight, and impact
+
+**Graph-native impact signals are computable and cheap.** The CD /
+disruption index ([Funk and Owen-Smith 2017][funk]; validated at scale
+by [Wu, Wang, Evans 2019][wu], Nature) labels a paper disruptive
+versus consolidating purely from citation-network structure. Uzzi et
+al. ([2013 Science][uzzi]) score atypicality from z-scored reference
+co-occurrence. node2vec ([1607.00653][n2v]) and Adamic-Adar
+([2003][aa]) predict missing edges for "papers you should read next."
+
+**But raw citation metrics are biased and must be normalized.** This
+is the strongest cross-channel warning in the entire study. The
+disruption index is biased by citation inflation and is unsuitable for
+cross-time comparison ([Petersen 2023][pet]; [QSS/MIT][qss]); it
+depends on the analyst-chosen citation-window length (so it is
+tunable and gameable) ([window][win]); disruption and novelty barely
+overlap as constructs ([Triadic Novelty][triadic]); and the famous
+small-teams-disrupt finding partly dissolves once inflation is
+corrected ([re-analysis][reana]).
+
+**Implication for tome.** Impact and novelty metrics are worth
+shipping, but only field-normalized and cohort-restricted (compare
+within discipline and publication-year band), with the citation window
+fixed and disclosed. Present them as one structural signal among
+several, never as a single "value" number. This is an evidence-backed
+guardrail, not a nice-to-have.
+
+## Cross-cutting design implications
+
+The TRIZ channel framed the core contradiction (comprehensiveness
+versus performance/legibility) and its resolution, which the other
+three channels' evidence independently supports:
+
+1. **Reuse over rebuild.** The knowledge graph
+   (`memory_palace.knowledge_graph.KnowledgeGraph`: entities,
+   temporal triples, weighted synapses), its analytics
+   (`PalaceGraphAnalyzer`: `pagerank`, `detect_communities`,
+   `predict_links` via Adamic-Adar), embeddings (`EmbeddingIndex` with
+   a dependency-free hash fallback), and `decay_model` already exist in
+   this repo. Tome's `export.py` stops at markdown and never writes to
+   them. Wiring tome into them is the highest-value, lowest-code move.
+2. **Tiered, on-condition escalation.** Keep a small hot working set
+   (summaries, embeddings, recent nodes); reach the full graph and
+   full text only when the query is multi-hop. This is TRIZ separation
+   in space and on condition, and it matches the GraphRAG "when to use
+   graphs" evidence.
+3. **Off-line consolidation with decay.** Attach a stability score to
+   nodes and edges; let unused ones decay and prune on a schedule, not
+   on the read path. `memory_palace.corpus.decay_model` already
+   implements the half-life machinery.
+4. **Cheap proxies rank, expensive reading is reserved.** Use
+   centrality and citation proxies to pick the top-k papers that earn
+   full-text loading, so most ranking costs no tokens.
+5. **Bandit-style research paths.** Generate "further research paths"
+   with an explicit exploit/explore split and an exploration-saturation
+   stop rule, so suggestions are novel-and-relevant and bounded, not a
+   flood.
+6. **Minimal dependency spine.** `networkx` (already a `memory-palace`
+   dependency) gives PageRank and Adamic-Adar with zero hard deps;
+   `arxiv.py`, `pyalex`, and `semanticscholar` are `requests`-only
+   clients; a hand-rolled or `pytrec_eval` nDCG gives deterministic
+   metrics with no LLM. Everything heavier (GROBID sidecar,
+   microsoft/graphrag, PyTorch Geometric, LLM-judge eval) stays behind
+   an optional extra or a service boundary.
+
+## Recommended adoption (prioritized)
+
+| Priority | Move | Basis |
+|----------|------|-------|
+| 1 | Keep citation edges; write papers as entities and citations as triples/synapses into `memory-palace` `KnowledgeGraph` | reuse; ground-truth edges avoid LLM-construction failure ([KAG][kag]) |
+| 2 | `detect_communities` = common threads; `predict_links` (Adamic-Adar) + node2vec = further research paths | [HippoRAG][hr], [n2v][n2v], [aa][aa]; reuse `graph_analyzer` |
+| 3 | Deterministic metrics harness (nDCG/MRR/recall@k) on a hand-labeled arXiv gold set; LLM-judge faithfulness optional | [BEIR][beir], [TREC][trec]; distrust of judges ([gm][gm], [ev][ev]) |
+| 4 | Structured paper model (sections + references); thin API ingest, GROBID sidecar optional; fix README PDF claim | [GROBID][grobid], [unarXive][unarxive], [Meuschke][meu] |
+| 5 | Field-and-cohort-normalized impact/novelty (CD index, atypicality) with fixed citation window | [Funk][funk], [Uzzi][uzzi], with [Petersen][pet]/[QSS][qss] corrections |
+| 6 | On-condition graph escalation + decay-based pruning | [when-to-graph][wtg], TRIZ; reuse `decay_model` |
+
+## Adoption risks
+
+- **Over-building the graph.** Evidence says graph value is real but
+  bounded to multi-hop. Guard: escalate on condition; measure the
+  before/after delta on a multi-hop benchmark ([MultiHop-RAG][mhr]) and
+  drop the graph path if it does not beat vector retrieval.
+- **Trusting LLM-judge metrics.** 0.55 human correlation, 12 biases.
+  Guard: deterministic metrics are the headline; judges are labeled
+  "directional."
+- **Shipping biased impact numbers.** Citation metrics are confounded
+  and gameable. Guard: normalize by field and cohort; fix and disclose
+  the citation window; never collapse to one number.
+- **Supply-chain surface.** Nougat model weights are CC-BY-NC
+  (non-commercial); OpenAlex now mandates an API key (Feb 2026);
+  nano-graphrag and Nougat are stale. Guard: keep the heavy tier
+  optional and vendored/isolated; run `leyline:supply-chain-advisory`
+  on any new dependency.
+- **Tool-coverage gaps in this study.** Reddit and Lobsters returned no
+  usable primary discourse (fetch blocks); Semantic Scholar
+  rate-limited citation counts. The academic and HN/blog channels
+  triangulated the key claims, but community breadth is thinner than
+  ideal. A rerun with an authenticated Reddit source would strengthen
+  the practitioner picture.
+
+[gr]: https://arxiv.org/abs/2404.16130
+[lr]: https://arxiv.org/abs/2410.05779
+[hr]: https://arxiv.org/abs/2405.14831
+[grb]: https://arxiv.org/abs/2506.02404
+[wtg]: https://arxiv.org/abs/2506.05690
+[kag]: https://news.ycombinator.com/item?id=42545986
+[cc]: https://medium.com/graph-praxis/the-graphrag-cost-cliff-how-33-000-became-33-in-eighteen-months-be1b0fbe37e4
+[tp]: https://tianpan.co/blog/2026-04-19-graphrag-vs-vector-rag-architecture-decision
+[beir]: https://arxiv.org/abs/2104.08663
+[trec]: https://arxiv.org/abs/2003.07820
+[ragas]: https://arxiv.org/abs/2309.15217
+[ares]: https://arxiv.org/abs/2311.09476
+[gm]: https://www.getmaxim.ai/articles/complete-guide-to-rag-evaluation-metrics-methods-and-best-practices-for-2025/
+[ev]: https://www.evidentlyai.com/llm-guide/llm-as-a-judge
+[rag-ready]: https://news.ycombinator.com/item?id=44701172
+[grobid]: https://github.com/kermitt2/grobid
+[meu]: https://gipplab.uni-goettingen.de/wp-content/papercite-data/pdf/meuschke2023.pdf
+[nougat]: https://arxiv.org/abs/2308.13418
+[pdfcmp]: https://arxiv.org/abs/2410.09871
+[cc2]: https://codecut.ai/docling-vs-marker-vs-llamaparse/
+[unarxive]: https://arxiv.org/abs/2303.14957
+[s2orc]: https://arxiv.org/abs/1911.02782
+[funk]: https://www.nature.com/articles/s41586-019-0941-9
+[wu]: https://www.nature.com/articles/s41586-019-0941-9
+[uzzi]: https://www.science.org/doi/10.1126/science.1240474
+[n2v]: https://arxiv.org/abs/1607.00653
+[aa]: https://www.sciencedirect.com/science/article/abs/pii/S0378873303000091
+[pet]: https://arxiv.org/abs/2306.01949
+[qss]: https://direct.mit.edu/qss/article/5/4/936/124788/The-disruption-index-is-biased-by-citation
+[win]: https://www.researchgate.net/publication/345473456_Disruption_index_depends_on_length_of_citation_window
+[triadic]: https://arxiv.org/pdf/2506.17851
+[reana]: https://www.sciencedirect.com/science/article/pii/S1751157724001172
+[mhr]: https://arxiv.org/abs/2401.15391

--- a/plugins/memory-palace/data/indexes/vitality-scores.yaml
+++ b/plugins/memory-palace/data/indexes/vitality-scores.yaml
@@ -1,6 +1,6 @@
 entries: {}
 metadata:
-  last_recomputed: '2026-07-13T16:23:41.194364+00:00'
+  last_recomputed: '2026-07-17T15:48:31.246897+00:00'
   decay_per_day: 1
   promotion_thresholds:
     growing: 30

--- a/plugins/memory-palace/src/memory_palace/__init__.py
+++ b/plugins/memory-palace/src/memory_palace/__init__.py
@@ -4,6 +4,7 @@ Provides spatial knowledge organization using memory palace techniques.
 """
 
 from .garden_metrics import compute_garden_metrics
+from .knowledge_graph import KnowledgeGraph
 from .palace_manager import MemoryPalaceManager
 from .project_palace import (
     ProjectPalaceManager,
@@ -16,6 +17,7 @@ from .project_palace import (
 from .session_history import SessionHistoryManager, SessionQuery, SessionRecord
 
 __all__ = [
+    "KnowledgeGraph",
     "MemoryPalaceManager",
     "ProjectPalaceManager",
     "ReviewEntry",

--- a/plugins/memory-palace/src/memory_palace/__init__.py
+++ b/plugins/memory-palace/src/memory_palace/__init__.py
@@ -3,6 +3,7 @@
 Provides spatial knowledge organization using memory palace techniques.
 """
 
+from .corpus.embedding_index import EmbeddingIndex
 from .garden_metrics import compute_garden_metrics
 from .graph_analyzer import PalaceGraphAnalyzer
 from .knowledge_graph import KnowledgeGraph
@@ -18,6 +19,7 @@ from .project_palace import (
 from .session_history import SessionHistoryManager, SessionQuery, SessionRecord
 
 __all__ = [
+    "EmbeddingIndex",
     "KnowledgeGraph",
     "MemoryPalaceManager",
     "PalaceGraphAnalyzer",

--- a/plugins/memory-palace/src/memory_palace/__init__.py
+++ b/plugins/memory-palace/src/memory_palace/__init__.py
@@ -4,6 +4,7 @@ Provides spatial knowledge organization using memory palace techniques.
 """
 
 from .garden_metrics import compute_garden_metrics
+from .graph_analyzer import PalaceGraphAnalyzer
 from .knowledge_graph import KnowledgeGraph
 from .palace_manager import MemoryPalaceManager
 from .project_palace import (
@@ -19,6 +20,7 @@ from .session_history import SessionHistoryManager, SessionQuery, SessionRecord
 __all__ = [
     "KnowledgeGraph",
     "MemoryPalaceManager",
+    "PalaceGraphAnalyzer",
     "ProjectPalaceManager",
     "ReviewEntry",
     "ReviewSubroom",

--- a/plugins/tome/Makefile
+++ b/plugins/tome/Makefile
@@ -7,7 +7,7 @@
 	security clean ci status debug-variables fix \
 	demo-classify demo-plan demo-skills demo-channels plugin-check \
 	test-channels test-synthesis test-output \
-	mutation-test benchmark memory-profile
+	mutation-test benchmark memory-profile metrics
 
 # Plugin-specific variables (must be before include)
 SRC_DIRS := src tests
@@ -47,6 +47,9 @@ test-synthesis: ## Run synthesis tests (merger, ranker)
 
 test-output: ## Run output tests (export, visualizer)
 	$(PYTEST) tests/output/ -v --tb=short
+
+metrics: ## Score the retrieval gold set (offline, no network)
+	$(UV_RUN) python -m tome.metrics.harness
 
 # ---------- Code Quality ----------
 fix: ## Auto-fix lint issues

--- a/plugins/tome/README.md
+++ b/plugins/tome/README.md
@@ -28,8 +28,9 @@ high-quality domains.
 
 **Academic literature**: arXiv, Semantic Scholar, with an
 open-access discovery chain (Unpaywall, CORE, PubMed
-Central, OpenAlex). Parses PDFs and provides fallback
-guidance for paywalled content.
+Central, OpenAlex). Routes PDFs through markitdown for the
+agent to read, and provides fallback guidance for paywalled
+content.
 
 **TRIZ cross-domain**: Identifies adjacent fields where
 analogous problems have been solved. Depth scales

--- a/plugins/tome/pyproject.toml
+++ b/plugins/tome/pyproject.toml
@@ -73,6 +73,10 @@ module = ["leyline.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = ["memory_palace", "memory_palace.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = ["tome.session"]
 disable_error_code = ["no-redef", "misc", "type-arg", "no-any-return"]
 

--- a/plugins/tome/src/tome/channels/academic.py
+++ b/plugins/tome/src/tome/channels/academic.py
@@ -14,7 +14,7 @@ from typing import Any
 from urllib.parse import quote, quote_plus
 
 from tome.channels import deduplicate_queries
-from tome.models import Finding
+from tome.models import CitationEdge, Finding
 
 # ---------------------------------------------------------------------------
 # Query Expansion
@@ -585,6 +585,63 @@ def parse_citation_chain_response(data: dict[str, Any]) -> list[Finding]:
         )
 
     return findings
+
+
+def parse_citation_edges(
+    data: dict[str, Any], source_paper_id: str
+) -> list[CitationEdge]:
+    """Parse S2 references/citations into directed :class:`CitationEdge`.
+
+    ``parse_citation_chain_response`` keeps the target papers but drops
+    the relationship. This keeps it: a ``/references`` item means
+    *source cites target*; a ``/citations`` item means *target cites
+    source*. Edges are emitted only when both endpoints have a real
+    paper ID, so no dangling half-edge enters the graph.
+
+    Args:
+        data: Parsed JSON from the S2 references or citations endpoint.
+        source_paper_id: The paper whose chain this response describes.
+
+    Returns:
+        Directed citation edges by S2 paper ID.
+
+    Raises:
+        ValueError: If ``source_paper_id`` is empty. An edge without a
+            real source is meaningless; this is designed out, not
+            silently skipped.
+    """
+    if not source_paper_id:
+        raise ValueError("source_paper_id must be a non-empty paper ID")
+
+    edges: list[CitationEdge] = []
+    items = data.get("data", [])
+    if not isinstance(items, list):
+        return edges
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        # References use "citedPaper" (source cites it); citations use
+        # "citingPaper" (it cites source). The key sets edge direction.
+        if "citedPaper" in item:
+            paper, source_is_citing = item.get("citedPaper") or {}, True
+        elif "citingPaper" in item:
+            paper, source_is_citing = item.get("citingPaper") or {}, False
+        else:
+            continue
+        if not isinstance(paper, dict):
+            continue
+
+        other_id: str = paper.get("paperId") or ""
+        if not other_id:
+            continue
+
+        if source_is_citing:
+            edges.append(CitationEdge(citing_id=source_paper_id, cited_id=other_id))
+        else:
+            edges.append(CitationEdge(citing_id=other_id, cited_id=source_paper_id))
+
+    return edges
 
 
 def build_paper_summary_prompt(title: str, abstract: str) -> str:

--- a/plugins/tome/src/tome/graph/__init__.py
+++ b/plugins/tome/src/tome/graph/__init__.py
@@ -1,0 +1,1 @@
+"""Knowledge-graph seam for tome (reuses memory-palace when present)."""

--- a/plugins/tome/src/tome/graph/palace_adapter.py
+++ b/plugins/tome/src/tome/graph/palace_adapter.py
@@ -1,0 +1,99 @@
+"""Citation-graph seam over memory-palace's KnowledgeGraph.
+
+tome does not hard-depend on memory-palace: the two are isolated
+plugins. This module imports the graph backend lazily and fails
+explicitly when it is absent, rather than degrading to a silent no-op
+that would ship dead graph features. The backend contract is expressed
+as the :class:`GraphWriter` protocol, which memory-palace's
+``KnowledgeGraph`` satisfies structurally, so no translation layer is
+needed. A tome-native backend could implement the same protocol later.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from tome.models import CitationEdge
+
+try:  # memory-palace is an optional, co-installed backend
+    from memory_palace import KnowledgeGraph as _KnowledgeGraph
+except ImportError:
+    _KnowledgeGraph = None
+
+_PAPER_ENTITY = "paper"
+_CITES_PREDICATE = "cites"
+
+
+class GraphBackendUnavailable(RuntimeError):
+    """Raised when no knowledge-graph backend can be loaded."""
+
+
+@runtime_checkable
+class GraphWriter(Protocol):
+    """The minimal write surface tome needs from a knowledge graph."""
+
+    def upsert_entity(
+        self,
+        entity_id: str,
+        entity_type: str,
+        name: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None: ...
+
+    def add_triple(
+        self,
+        subject_id: str,
+        predicate: str,
+        object_id: str,
+        *args: Any,
+        **kwargs: Any,
+    ) -> int: ...
+
+
+def memory_palace_available() -> bool:
+    """Return whether the memory-palace graph backend is importable."""
+    return _KnowledgeGraph is not None
+
+
+def open_palace_graph(db_path: str) -> GraphWriter:
+    """Open a memory-palace ``KnowledgeGraph`` at ``db_path``.
+
+    Consumes memory-palace's public API (``KnowledgeGraph`` is exported
+    from the package root), not an unexported submodule.
+
+    Raises:
+        GraphBackendUnavailable: When memory-palace is not installed.
+            This is an explicit capability failure, deliberately not a
+            silent fallback.
+    """
+    if _KnowledgeGraph is None:
+        raise GraphBackendUnavailable(
+            "the tome graph feature requires memory-palace, which is not installed"
+        )
+    graph: GraphWriter = _KnowledgeGraph(db_path)
+    return graph
+
+
+class CitationGraphWriter:
+    """Write :class:`CitationEdge` batches into a knowledge graph.
+
+    Each paper ID becomes a ``paper`` entity and each edge becomes a
+    ``cites`` triple. Entity upserts are deduplicated within a batch;
+    the backend upsert is idempotent regardless.
+    """
+
+    def __init__(self, backend: GraphWriter) -> None:
+        self._backend = backend
+
+    def write_edges(self, edges: list[CitationEdge]) -> int:
+        """Write ``edges`` and return the number of triples written."""
+        seen: set[str] = set()
+        written = 0
+        for edge in edges:
+            for paper_id in (edge.citing_id, edge.cited_id):
+                if paper_id not in seen:
+                    self._backend.upsert_entity(paper_id, _PAPER_ENTITY, paper_id)
+                    seen.add(paper_id)
+            self._backend.add_triple(edge.citing_id, _CITES_PREDICATE, edge.cited_id)
+            written += 1
+        return written

--- a/plugins/tome/src/tome/graph/threads.py
+++ b/plugins/tome/src/tome/graph/threads.py
@@ -1,0 +1,87 @@
+"""Research threads and paths over the citation graph.
+
+Wraps memory-palace's ``PalaceGraphAnalyzer``: community detection
+surfaces "common threads" (clusters of related papers) and link
+prediction surfaces "further research paths" (suggested connections).
+As with the writer seam, the analyzer backend is optional and loaded
+via a guarded import; its absence is an explicit failure, not a silent
+no-op.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from tome.graph.palace_adapter import GraphBackendUnavailable
+
+try:  # memory-palace is an optional, co-installed backend
+    from memory_palace import PalaceGraphAnalyzer as _PalaceGraphAnalyzer
+except ImportError:
+    _PalaceGraphAnalyzer = None
+
+
+@dataclass(frozen=True)
+class ResearchThread:
+    """A cluster of related papers: a detected community in the graph."""
+
+    thread_id: int
+    paper_ids: frozenset[str]
+
+
+@dataclass(frozen=True)
+class ResearchPath:
+    """A suggested next connection: a predicted citation link."""
+
+    from_id: str
+    to_id: str
+    score: float
+
+
+@runtime_checkable
+class GraphAnalyzer(Protocol):
+    """The read surface tome needs for threads and paths."""
+
+    def detect_communities(self) -> dict[int, set[str]]: ...
+
+    def predict_links(self, top_n: int = 10) -> list[tuple[str, str, float]]: ...
+
+
+def analyzer_available() -> bool:
+    """Return whether the graph-analyzer backend is importable."""
+    return _PalaceGraphAnalyzer is not None
+
+
+def open_analyzer(graph: Any) -> GraphAnalyzer:
+    """Build a ``PalaceGraphAnalyzer`` over ``graph``.
+
+    Raises:
+        GraphBackendUnavailable: When memory-palace is not installed.
+    """
+    if _PalaceGraphAnalyzer is None:
+        raise GraphBackendUnavailable(
+            "research threads require memory-palace, which is not installed"
+        )
+    analyzer: GraphAnalyzer = _PalaceGraphAnalyzer(graph)
+    return analyzer
+
+
+class ThreadFinder:
+    """Derive research threads and paths from a graph analyzer."""
+
+    def __init__(self, analyzer: GraphAnalyzer) -> None:
+        self._analyzer = analyzer
+
+    def common_threads(self) -> list[ResearchThread]:
+        """Return detected communities as research threads."""
+        return [
+            ResearchThread(thread_id, frozenset(members))
+            for thread_id, members in self._analyzer.detect_communities().items()
+        ]
+
+    def research_paths(self, top_n: int = 10) -> list[ResearchPath]:
+        """Return the top predicted links as further-research paths."""
+        return [
+            ResearchPath(from_id=src, to_id=dst, score=score)
+            for src, dst, score in self._analyzer.predict_links(top_n=top_n)
+        ]

--- a/plugins/tome/src/tome/metrics/__init__.py
+++ b/plugins/tome/src/tome/metrics/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic research-quality metrics (offline, no LLM)."""

--- a/plugins/tome/src/tome/metrics/corpus.py
+++ b/plugins/tome/src/tome/metrics/corpus.py
@@ -1,0 +1,40 @@
+"""Deterministic corpus-quality metrics over a set of findings.
+
+Diversity (a creativity proxy) and efficiency (performance proxies).
+All pure functions: no network, no model, no cross-plugin backend.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from tome.models import Finding
+
+
+def source_diversity(findings: list[Finding]) -> float:
+    """Return ``1 - Herfindahl`` over channels, in ``[0.0, 1.0)``.
+
+    0.0 when every finding shares one channel; approaches 1.0 as the set
+    spreads evenly across many channels. This is the same diversity term
+    the synthesis quality score uses, exposed as a standalone metric.
+    """
+    if not findings:
+        return 0.0
+    counts = Counter(finding.channel for finding in findings)
+    total = len(findings)
+    herfindahl = sum((count / total) ** 2 for count in counts.values())
+    return 1.0 - herfindahl
+
+
+def dedup_ratio(before: int, after: int) -> float:
+    """Fraction of findings removed by deduplication; 0.0 if ``before`` is 0."""
+    if before <= 0:
+        return 0.0
+    return (before - after) / before
+
+
+def findings_per_1k_tokens(count: int, tokens: int) -> float:
+    """Findings yielded per 1000 tokens spent; 0.0 when no tokens spent."""
+    if tokens <= 0:
+        return 0.0
+    return count / (tokens / 1000)

--- a/plugins/tome/src/tome/metrics/fixtures/gold_set.yaml
+++ b/plugins/tome/src/tome/metrics/fixtures/gold_set.yaml
@@ -1,0 +1,13 @@
+# Offline retrieval gold set for `make metrics`. Synthetic paper IDs:
+# each topic lists the retriever's ranked output and the relevant set.
+# Replace with real labeled arXiv topics to benchmark a live pipeline.
+items:
+  - topic: graph rag construction
+    ranked: [p1, p2, p3, p4, p5]
+    relevant: [p1, p3]
+  - topic: rag evaluation metrics
+    ranked: [q1, q2, q3, q4]
+    relevant: [q2, q4]
+  - topic: scientific pdf ingestion
+    ranked: [r1, r2, r3]
+    relevant: [r3]

--- a/plugins/tome/src/tome/metrics/harness.py
+++ b/plugins/tome/src/tome/metrics/harness.py
@@ -1,0 +1,92 @@
+"""Offline retrieval-metrics benchmark (the ``make metrics`` harness).
+
+Loads a committed gold set (topics, each with a ranked result list and a
+relevant set), scores mean nDCG / MRR / recall with the deterministic
+functions in :mod:`tome.metrics.retrieval`, and prints a table. No
+network, no model, no LLM: the numbers are reproducible and trend-able.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from tome.metrics.retrieval import mrr, ndcg_at_k, recall_at_k
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "gold_set.yaml"
+
+
+@dataclass(frozen=True)
+class GoldItem:
+    """A gold-labeled topic: the ranked result IDs and the relevant set."""
+
+    topic: str
+    ranked_ids: list[str]
+    relevant: frozenset[str]
+
+
+@dataclass(frozen=True)
+class RetrievalReport:
+    """Aggregate retrieval metrics over a gold set."""
+
+    k: int
+    n_topics: int
+    mean_ndcg: float
+    mean_mrr: float
+    mean_recall: float
+
+    def render(self) -> str:
+        """Render the report as a plain-text table."""
+        return (
+            f"Retrieval metrics (mean over {self.n_topics} topics, k={self.k}):\n"
+            f"  nDCG@{self.k}:   {self.mean_ndcg:.3f}\n"
+            f"  MRR:        {self.mean_mrr:.3f}\n"
+            f"  recall@{self.k}: {self.mean_recall:.3f}\n"
+        )
+
+
+def load_gold_set(path: Path | str = _FIXTURE) -> list[GoldItem]:
+    """Load a gold set from a YAML file (defaults to the shipped fixture)."""
+    data = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+    items = data.get("items", [])
+    return [
+        GoldItem(
+            topic=str(item["topic"]),
+            ranked_ids=[str(i) for i in item["ranked"]],
+            relevant=frozenset(str(i) for i in item["relevant"]),
+        )
+        for item in items
+    ]
+
+
+def evaluate(gold: list[GoldItem], k: int = 10) -> RetrievalReport:
+    """Compute mean nDCG / MRR / recall across the gold items."""
+    if not gold:
+        return RetrievalReport(
+            k=k, n_topics=0, mean_ndcg=0.0, mean_mrr=0.0, mean_recall=0.0
+        )
+    count = len(gold)
+    mean_ndcg = sum(ndcg_at_k(g.ranked_ids, set(g.relevant), k) for g in gold) / count
+    mean_mrr = sum(mrr(g.ranked_ids, set(g.relevant)) for g in gold) / count
+    mean_recall = (
+        sum(recall_at_k(g.ranked_ids, set(g.relevant), k) for g in gold) / count
+    )
+    return RetrievalReport(
+        k=k,
+        n_topics=count,
+        mean_ndcg=mean_ndcg,
+        mean_mrr=mean_mrr,
+        mean_recall=mean_recall,
+    )
+
+
+def main() -> None:
+    """Score the shipped gold set and print the report."""
+    report = evaluate(load_gold_set())
+    print(report.render())
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/tome/src/tome/metrics/impact.py
+++ b/plugins/tome/src/tome/metrics/impact.py
@@ -1,0 +1,78 @@
+"""Impact metrics over the citation graph.
+
+Two families. ``disruption_index`` computes the CD index (Funk and
+Owen-Smith 2017): does a paper's citing works ignore its intellectual
+predecessors (disruptive, toward +1) or cite them too (consolidating,
+toward -1)? ``rank_by_centrality`` orders papers by PageRank produced by
+memory-palace's analyzer.
+
+The disruption index is biased by citation inflation, field size, and
+citation-window length (Petersen 2023; QSS 2024). So a raw score is
+never comparable across cohorts: ``assert_comparable`` enforces that in
+code, not just in prose.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+def disruption_index(citing_focal: set[str], citing_references: set[str]) -> float:
+    """CD index in ``[-1.0, 1.0]`` from two citing-paper sets.
+
+    Args:
+        citing_focal: IDs of papers that cite the focal paper.
+        citing_references: IDs of papers that cite the focal paper's
+            references (its intellectual predecessors).
+
+    Returns:
+        ``(n_i - n_j) / (n_i + n_j + n_k)`` where ``n_i`` cite only the
+        focal (disruptive), ``n_j`` cite both (consolidating), and
+        ``n_k`` cite only the references. ``0.0`` when no citing papers.
+    """
+    n_i = len(citing_focal - citing_references)
+    n_j = len(citing_focal & citing_references)
+    n_k = len(citing_references - citing_focal)
+    denominator = n_i + n_j + n_k
+    if denominator == 0:
+        return 0.0
+    return (n_i - n_j) / denominator
+
+
+@dataclass(frozen=True)
+class Cohort:
+    """A comparison cohort: same field and publication year."""
+
+    field: str
+    year: int
+
+
+@dataclass(frozen=True)
+class DisruptionScore:
+    """A disruption score tagged with the cohort it was measured in."""
+
+    paper_id: str
+    score: float
+    cohort: Cohort
+
+
+def assert_comparable(a: DisruptionScore, b: DisruptionScore) -> None:
+    """Raise unless two disruption scores share a cohort.
+
+    Cross-cohort comparison of raw disruption is invalid: the index is
+    confounded by citation inflation and field size. Comparing only
+    within a field-and-year cohort is the documented correction.
+
+    Raises:
+        ValueError: When the two scores are from different cohorts.
+    """
+    if a.cohort != b.cohort:
+        raise ValueError(
+            f"disruption scores are not comparable across cohorts: "
+            f"{a.cohort} vs {b.cohort}"
+        )
+
+
+def rank_by_centrality(pagerank: dict[str, float]) -> list[tuple[str, float]]:
+    """Rank paper IDs by PageRank centrality, most central first."""
+    return sorted(pagerank.items(), key=lambda item: item[1], reverse=True)

--- a/plugins/tome/src/tome/metrics/retrieval.py
+++ b/plugins/tome/src/tome/metrics/retrieval.py
@@ -1,0 +1,47 @@
+"""Deterministic information-retrieval metrics.
+
+nDCG, MRR, and recall against a gold-relevant set. These are the
+trustworthy, label-based yardstick the research favored over
+LLM-judged scores. Binary relevance: an item is relevant if its ID is
+in the gold set. No dependencies, no network, no model.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def _dcg(ranked_ids: list[str], relevant: set[str], k: int) -> float:
+    """Discounted cumulative gain over the top ``k`` with binary gains."""
+    total = 0.0
+    for index, item_id in enumerate(ranked_ids[:k]):
+        if item_id in relevant:
+            total += 1.0 / math.log2(index + 2)
+    return total
+
+
+def ndcg_at_k(ranked_ids: list[str], relevant: set[str], k: int) -> float:
+    """Normalized DCG at ``k``; 0.0 when there are no relevant items."""
+    if not relevant:
+        return 0.0
+    ideal_hits = min(len(relevant), k)
+    idcg = sum(1.0 / math.log2(index + 2) for index in range(ideal_hits))
+    if idcg == 0.0:
+        return 0.0
+    return _dcg(ranked_ids, relevant, k) / idcg
+
+
+def mrr(ranked_ids: list[str], relevant: set[str]) -> float:
+    """Reciprocal rank of the first relevant item; 0.0 when none appear."""
+    for index, item_id in enumerate(ranked_ids):
+        if item_id in relevant:
+            return 1.0 / (index + 1)
+    return 0.0
+
+
+def recall_at_k(ranked_ids: list[str], relevant: set[str], k: int) -> float:
+    """Fraction of relevant items appearing in the top ``k``."""
+    if not relevant:
+        return 0.0
+    hits = sum(1 for item_id in ranked_ids[:k] if item_id in relevant)
+    return hits / len(relevant)

--- a/plugins/tome/src/tome/models.py
+++ b/plugins/tome/src/tome/models.py
@@ -57,6 +57,26 @@ class Finding:
             ) from exc
 
 
+@dataclass(frozen=True)
+class CitationEdge:
+    """A directed citation edge: ``citing_id`` cites ``cited_id``.
+
+    Both endpoints are Semantic Scholar paper IDs. The edge is the
+    relationship tome used to discard when flattening citation-chain
+    responses into a list of papers.
+    """
+
+    citing_id: str
+    cited_id: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"citing_id": self.citing_id, "cited_id": self.cited_id}
+
+    @classmethod
+    def from_dict(cls, d: dict[str, str]) -> CitationEdge:
+        return cls(citing_id=d["citing_id"], cited_id=d["cited_id"])
+
+
 @dataclass
 class DomainClassification:
     """Result of classifying a research topic into a domain."""

--- a/plugins/tome/src/tome/retrieval/__init__.py
+++ b/plugins/tome/src/tome/retrieval/__init__.py
@@ -1,0 +1,1 @@
+"""Semantic retrieval over findings (reuses memory-palace EmbeddingIndex)."""

--- a/plugins/tome/src/tome/retrieval/semantic.py
+++ b/plugins/tome/src/tome/retrieval/semantic.py
@@ -8,6 +8,7 @@ failure, matching the graph seam.
 
 from __future__ import annotations
 
+import importlib.util
 import math
 from typing import Protocol, runtime_checkable
 
@@ -39,13 +40,39 @@ def _cosine(a: list[float], b: list[float]) -> float:
     return dot / (norm_a * norm_b)
 
 
+_HASH_PROVIDER = "none"
+_MODEL_PROVIDER = "local"
+
+
 def embedder_available() -> bool:
     """Return whether the embedding backend is importable."""
     return _EmbeddingIndex is not None
 
 
-def open_embedder(embeddings_path: str) -> Embedder:
-    """Open a memory-palace ``EmbeddingIndex`` with the hash provider.
+def best_available_provider() -> str:
+    """Pick the real embedding provider when possible, else the fallback.
+
+    ``"local"`` (sentence-transformers) produces semantically meaningful
+    vectors. ``"none"`` is the dependency-free SHA-256 fallback: it is
+    deterministic but NOT semantic, so ranking over it is not meaningful.
+    Pass the result to :func:`open_embedder` to use the real model
+    whenever it is installed.
+    """
+    try:
+        found = importlib.util.find_spec("sentence_transformers") is not None
+    except (ImportError, ValueError):
+        return _HASH_PROVIDER
+    return _MODEL_PROVIDER if found else _HASH_PROVIDER
+
+
+def open_embedder(embeddings_path: str, provider: str = _HASH_PROVIDER) -> Embedder:
+    """Open a memory-palace ``EmbeddingIndex``.
+
+    Args:
+        embeddings_path: Where the index persists its vectors.
+        provider: ``"local"`` for sentence-transformers (real semantic
+            vectors) or ``"none"`` for the hash fallback. Call
+            :func:`best_available_provider` to auto-select.
 
     Raises:
         GraphBackendUnavailable: When memory-palace is not installed.
@@ -54,7 +81,7 @@ def open_embedder(embeddings_path: str) -> Embedder:
         raise GraphBackendUnavailable(
             "semantic retrieval requires memory-palace, which is not installed"
         )
-    embedder: Embedder = _EmbeddingIndex(embeddings_path, provider="none")
+    embedder: Embedder = _EmbeddingIndex(embeddings_path, provider=provider)
     return embedder
 
 

--- a/plugins/tome/src/tome/retrieval/semantic.py
+++ b/plugins/tome/src/tome/retrieval/semantic.py
@@ -1,0 +1,84 @@
+"""Semantic ranking of findings over an embedding backend.
+
+Reuses memory-palace's ``EmbeddingIndex`` (which ships a dependency-free
+SHA-256 hash-vector fallback, so no new hard dependency). The backend is
+optional and loaded via a guarded import; its absence is an explicit
+failure, matching the graph seam.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Protocol, runtime_checkable
+
+from tome.graph.palace_adapter import GraphBackendUnavailable
+from tome.models import Finding
+
+try:  # memory-palace is an optional, co-installed backend
+    from memory_palace import EmbeddingIndex as _EmbeddingIndex
+except ImportError:
+    _EmbeddingIndex = None
+
+
+@runtime_checkable
+class Embedder(Protocol):
+    """The minimal surface tome needs to embed text."""
+
+    def vectorize(self, text: str) -> list[float]: ...
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    """Cosine similarity of two vectors; 0.0 if either is degenerate."""
+    if len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def embedder_available() -> bool:
+    """Return whether the embedding backend is importable."""
+    return _EmbeddingIndex is not None
+
+
+def open_embedder(embeddings_path: str) -> Embedder:
+    """Open a memory-palace ``EmbeddingIndex`` with the hash provider.
+
+    Raises:
+        GraphBackendUnavailable: When memory-palace is not installed.
+    """
+    if _EmbeddingIndex is None:
+        raise GraphBackendUnavailable(
+            "semantic retrieval requires memory-palace, which is not installed"
+        )
+    embedder: Embedder = _EmbeddingIndex(embeddings_path, provider="none")
+    return embedder
+
+
+class SemanticRetriever:
+    """Rank findings by embedding similarity to a query."""
+
+    def __init__(self, embedder: Embedder) -> None:
+        self._embedder = embedder
+
+    def rank(
+        self, query: str, findings: list[Finding], top_k: int | None = None
+    ) -> list[Finding]:
+        """Return findings ordered by cosine similarity to ``query``."""
+        if not findings:
+            return []
+        query_vec = self._embedder.vectorize(query)
+        scored: list[tuple[Finding, float]] = [
+            (finding, _cosine(query_vec, self._embedder.vectorize(self._text(finding))))
+            for finding in findings
+        ]
+        scored.sort(key=lambda pair: pair[1], reverse=True)
+        ranked = [finding for finding, _ in scored]
+        return ranked[:top_k] if top_k is not None else ranked
+
+    @staticmethod
+    def _text(finding: Finding) -> str:
+        return f"{finding.title}. {finding.summary}"

--- a/plugins/tome/src/tome/synthesis/ranker.py
+++ b/plugins/tome/src/tome/synthesis/ranker.py
@@ -114,9 +114,25 @@ def compute_relevance_score(finding: Finding) -> float:
     return min(score, 1.0)
 
 
+def compute_ranked_score(finding: Finding, all_findings: list[Finding]) -> float:
+    """Relevance plus cross-channel triangulation, capped at 1.0.
+
+    This is the score ``rank_findings`` sorts by. It folds the
+    previously-dormant ``compute_triangulation_bonus`` into the ranking
+    so corroboration across channels is finally rewarded.
+    """
+    base = compute_relevance_score(finding)
+    bonus = compute_triangulation_bonus(finding, all_findings)
+    return min(base + bonus, 1.0)
+
+
 def rank_findings(findings: list[Finding]) -> list[Finding]:
-    """Return findings sorted by composite relevance score, descending."""
-    return sorted(findings, key=compute_relevance_score, reverse=True)
+    """Return findings sorted by relevance + triangulation, descending."""
+    return sorted(
+        findings,
+        key=lambda finding: compute_ranked_score(finding, findings),
+        reverse=True,
+    )
 
 
 def group_by_theme(findings: list[Finding]) -> dict[str, list[Finding]]:

--- a/plugins/tome/tests/channels/test_academic.py
+++ b/plugins/tome/tests/channels/test_academic.py
@@ -22,9 +22,11 @@ from tome.channels.academic import (
     estimate_page_chunks,
     generate_access_fallback_guidance,
     parse_arxiv_response,
+    parse_citation_edges,
     parse_semantic_scholar_response,
     parse_unpaywall_response,
 )
+from tome.models import CitationEdge
 
 # ---------------------------------------------------------------------------
 # Sample fixtures
@@ -754,3 +756,92 @@ class TestPdfProcessing:
         prompt = build_paper_summary_prompt("Title", "Abstract text here.")
 
         assert "limitation" in prompt.lower()
+
+
+# ---------------------------------------------------------------------------
+# Citation edges (Increment 1: keep the edges tome used to discard)
+# ---------------------------------------------------------------------------
+
+S2_REFERENCES_SAMPLE: dict[str, Any] = {
+    "data": [
+        {
+            "citedPaper": {
+                "paperId": "REF1",
+                "title": "Referenced Paper",
+                "year": 2020,
+                "citationCount": 100,
+                "externalIds": {"ArXiv": "2001.00001"},
+                "authors": [{"name": "A. Author"}],
+            }
+        },
+        {"citedPaper": {"paperId": "", "title": "Reference With No Id"}},
+    ]
+}
+
+S2_CITATIONS_SAMPLE: dict[str, Any] = {
+    "data": [
+        {
+            "citingPaper": {
+                "paperId": "CIT1",
+                "title": "Citing Paper",
+                "year": 2024,
+                "citationCount": 5,
+                "authors": [],
+            }
+        }
+    ]
+}
+
+
+class TestParseCitationEdges:
+    """
+    Scenario: keep the source->target citation relationship as a graph edge.
+    """
+
+    def test_references_produce_source_cites_target_edges(self) -> None:
+        """
+        Given a Semantic Scholar /references response for paper SRC
+        When I parse it for edges
+        Then SRC is recorded as citing each referenced paper
+        """
+        edges = parse_citation_edges(S2_REFERENCES_SAMPLE, source_paper_id="SRC")
+
+        assert edges == [CitationEdge(citing_id="SRC", cited_id="REF1")]
+
+    def test_citations_produce_target_cites_source_edges(self) -> None:
+        """
+        Given a Semantic Scholar /citations response for paper SRC
+        When I parse it for edges
+        Then each citing paper is recorded as citing SRC
+        """
+        edges = parse_citation_edges(S2_CITATIONS_SAMPLE, source_paper_id="SRC")
+
+        assert edges == [CitationEdge(citing_id="CIT1", cited_id="SRC")]
+
+    def test_edges_require_both_endpoints(self) -> None:
+        """
+        Given a referenced paper with no paperId
+        When I parse edges
+        Then no dangling edge is emitted (both endpoints must exist)
+        """
+        edges = parse_citation_edges(S2_REFERENCES_SAMPLE, source_paper_id="SRC")
+
+        assert all(e.citing_id and e.cited_id for e in edges)
+        assert len(edges) == 1
+
+    def test_missing_source_id_raises(self) -> None:
+        """
+        Given an empty source paper id
+        When I parse edges
+        Then a ValueError is raised (an edge needs a real source, not a guard)
+        """
+        with pytest.raises(ValueError, match="source_paper_id"):
+            parse_citation_edges(S2_REFERENCES_SAMPLE, source_paper_id="")
+
+
+class TestCitationEdgeModel:
+    """Scenario: CitationEdge round-trips through dict form."""
+
+    def test_round_trip(self) -> None:
+        edge = CitationEdge(citing_id="A", cited_id="B")
+        assert CitationEdge.from_dict(edge.to_dict()) == edge

--- a/plugins/tome/tests/graph/test_palace_adapter.py
+++ b/plugins/tome/tests/graph/test_palace_adapter.py
@@ -1,0 +1,134 @@
+"""
+Feature: Citation graph seam (build increment 2)
+
+As the tome research engine
+I want to write citation edges into a knowledge graph
+So that papers become linked entities instead of a flat list,
+reusing memory-palace's KnowledgeGraph without a hard dependency.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from tome.graph.palace_adapter import (
+    CitationGraphWriter,
+    GraphBackendUnavailable,
+    GraphWriter,
+    memory_palace_available,
+    open_palace_graph,
+)
+from tome.models import CitationEdge
+
+
+class FakeGraph:
+    """In-memory stand-in satisfying the GraphWriter protocol."""
+
+    def __init__(self) -> None:
+        self.entities: dict[str, tuple[str, str]] = {}
+        self.triples: list[tuple[str, str, str]] = []
+        self.upsert_calls: list[str] = []
+
+    def upsert_entity(
+        self,
+        entity_id: str,
+        entity_type: str,
+        name: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        self.upsert_calls.append(entity_id)
+        self.entities[entity_id] = (entity_type, name)
+
+    def add_triple(
+        self,
+        subject_id: str,
+        predicate: str,
+        object_id: str,
+        *args: Any,
+        **kwargs: Any,
+    ) -> int:
+        self.triples.append((subject_id, predicate, object_id))
+        return len(self.triples)
+
+
+class TestCitationGraphWriter:
+    @pytest.mark.unit
+    def test_writes_paper_entities_and_cites_triple(self) -> None:
+        """
+        Given one citation edge A -> B
+        When it is written to the graph
+        Then A and B are paper entities and A cites B
+        """
+        graph = FakeGraph()
+        writer = CitationGraphWriter(graph)
+
+        writer.write_edges([CitationEdge(citing_id="A", cited_id="B")])
+
+        assert graph.entities == {"A": ("paper", "A"), "B": ("paper", "B")}
+        assert graph.triples == [("A", "cites", "B")]
+
+    @pytest.mark.unit
+    def test_returns_edge_count(self) -> None:
+        graph = FakeGraph()
+        writer = CitationGraphWriter(graph)
+
+        count = writer.write_edges(
+            [
+                CitationEdge(citing_id="A", cited_id="B"),
+                CitationEdge(citing_id="A", cited_id="C"),
+            ]
+        )
+
+        assert count == 2
+
+    @pytest.mark.unit
+    def test_shared_paper_upserted_once_per_batch(self) -> None:
+        """A appears in two edges but is upserted a single time."""
+        graph = FakeGraph()
+        writer = CitationGraphWriter(graph)
+
+        writer.write_edges(
+            [
+                CitationEdge(citing_id="A", cited_id="B"),
+                CitationEdge(citing_id="A", cited_id="C"),
+            ]
+        )
+
+        assert graph.upsert_calls.count("A") == 1
+
+    @pytest.mark.unit
+    def test_fake_satisfies_protocol(self) -> None:
+        assert isinstance(FakeGraph(), GraphWriter)
+
+
+class TestBackendCapability:
+    @pytest.mark.unit
+    def test_availability_is_boolean(self) -> None:
+        assert isinstance(memory_palace_available(), bool)
+
+    @pytest.mark.unit
+    def test_open_raises_explicitly_when_unavailable(self) -> None:
+        """
+        The absence of memory-palace is an explicit failure, not a
+        silent no-op that ships dead graph features.
+        """
+        if memory_palace_available():
+            pytest.skip("memory-palace is installed; cannot test the absent path")
+        with pytest.raises(GraphBackendUnavailable, match="memory-palace"):
+            open_palace_graph(":memory:")
+
+
+class TestRealBackendContract:
+    """Runs only where memory-palace is installed (combined CI)."""
+
+    @pytest.mark.integration
+    def test_real_knowledge_graph_satisfies_writer(self, tmp_path: Any) -> None:
+        mp = pytest.importorskip("memory_palace")
+        graph = mp.KnowledgeGraph(str(tmp_path / "g.db"))
+        assert isinstance(graph, GraphWriter)
+
+        writer = CitationGraphWriter(graph)
+        written = writer.write_edges([CitationEdge(citing_id="P1", cited_id="P2")])
+
+        assert written == 1

--- a/plugins/tome/tests/graph/test_threads.py
+++ b/plugins/tome/tests/graph/test_threads.py
@@ -1,0 +1,107 @@
+"""
+Feature: research threads and paths (build increment 3)
+
+As the tome research engine
+I want communities and predicted links over the citation graph
+So that I can surface "common threads" and "further research paths",
+reusing memory-palace's PalaceGraphAnalyzer.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from tome.graph.palace_adapter import CitationGraphWriter, GraphBackendUnavailable
+from tome.graph.threads import (
+    GraphAnalyzer,
+    ResearchPath,
+    ResearchThread,
+    ThreadFinder,
+    analyzer_available,
+    open_analyzer,
+)
+from tome.models import CitationEdge
+
+
+class FakeAnalyzer:
+    """Stand-in satisfying the GraphAnalyzer protocol."""
+
+    def __init__(
+        self,
+        communities: dict[int, set[str]],
+        links: list[tuple[str, str, float]],
+    ) -> None:
+        self._communities = communities
+        self._links = links
+
+    def detect_communities(self) -> dict[int, set[str]]:
+        return self._communities
+
+    def predict_links(self, top_n: int = 10) -> list[tuple[str, str, float]]:
+        return self._links[:top_n]
+
+
+class TestThreadFinder:
+    @pytest.mark.unit
+    def test_common_threads_map_communities(self) -> None:
+        analyzer = FakeAnalyzer({0: {"A", "B"}, 1: {"C"}}, [])
+        finder = ThreadFinder(analyzer)
+
+        threads = finder.common_threads()
+
+        assert ResearchThread(0, frozenset({"A", "B"})) in threads
+        assert ResearchThread(1, frozenset({"C"})) in threads
+        assert len(threads) == 2
+
+    @pytest.mark.unit
+    def test_research_paths_map_predicted_links(self) -> None:
+        analyzer = FakeAnalyzer({}, [("A", "B", 0.9), ("A", "C", 0.4)])
+        finder = ThreadFinder(analyzer)
+
+        paths = finder.research_paths()
+
+        assert paths[0] == ResearchPath(from_id="A", to_id="B", score=0.9)
+        assert paths[1] == ResearchPath(from_id="A", to_id="C", score=0.4)
+
+    @pytest.mark.unit
+    def test_research_paths_respects_top_n(self) -> None:
+        analyzer = FakeAnalyzer({}, [("A", "B", 0.9), ("A", "C", 0.4)])
+        finder = ThreadFinder(analyzer)
+
+        assert len(finder.research_paths(top_n=1)) == 1
+
+    @pytest.mark.unit
+    def test_fake_satisfies_protocol(self) -> None:
+        assert isinstance(FakeAnalyzer({}, []), GraphAnalyzer)
+
+
+class TestOpenAnalyzer:
+    @pytest.mark.unit
+    def test_raises_explicitly_when_backend_absent(self) -> None:
+        if analyzer_available():
+            pytest.skip("memory-palace installed; cannot test absent path")
+        with pytest.raises(GraphBackendUnavailable, match="memory-palace"):
+            open_analyzer(object())
+
+
+class TestRealAnalyzerContract:
+    """Runs only where memory-palace is installed (combined CI)."""
+
+    @pytest.mark.integration
+    def test_threads_over_real_graph(self, tmp_path: Any) -> None:
+        mp = pytest.importorskip("memory_palace")
+
+        graph = mp.KnowledgeGraph(str(tmp_path / "g.db"))
+        CitationGraphWriter(graph).write_edges(
+            [
+                CitationEdge(citing_id="P1", cited_id="P2"),
+                CitationEdge(citing_id="P2", cited_id="P3"),
+            ]
+        )
+
+        finder = ThreadFinder(open_analyzer(graph))
+        # Communities/paths may be empty on a tiny graph, but the calls
+        # must succeed and return the right shapes.
+        assert isinstance(finder.common_threads(), list)
+        assert isinstance(finder.research_paths(top_n=5), list)

--- a/plugins/tome/tests/metrics/test_corpus.py
+++ b/plugins/tome/tests/metrics/test_corpus.py
@@ -1,0 +1,53 @@
+"""
+Feature: corpus-quality metrics (build increment 5)
+
+As the tome research engine
+I want diversity and efficiency measured over a finding set
+So that the creativity and performance dimensions have deterministic
+proxies.
+"""
+
+from __future__ import annotations
+
+import pytest
+from tome.metrics.corpus import dedup_ratio, findings_per_1k_tokens, source_diversity
+
+from tests.factories import make_finding
+
+
+class TestSourceDiversity:
+    @pytest.mark.unit
+    def test_single_channel_has_zero_diversity(self) -> None:
+        findings = [make_finding(0.5, channel="code") for _ in range(3)]
+        assert source_diversity(findings) == pytest.approx(0.0)
+
+    @pytest.mark.unit
+    def test_even_split_two_channels(self) -> None:
+        findings = [
+            make_finding(0.5, channel="code"),
+            make_finding(0.5, channel="academic"),
+        ]
+        # Herfindahl = 0.5^2 + 0.5^2 = 0.5; diversity = 1 - 0.5 = 0.5
+        assert source_diversity(findings) == pytest.approx(0.5)
+
+    @pytest.mark.unit
+    def test_empty_is_zero(self) -> None:
+        assert source_diversity([]) == 0.0
+
+
+class TestEfficiency:
+    @pytest.mark.unit
+    def test_dedup_ratio(self) -> None:
+        assert dedup_ratio(before=10, after=7) == pytest.approx(0.3)
+
+    @pytest.mark.unit
+    def test_dedup_ratio_zero_before_is_zero(self) -> None:
+        assert dedup_ratio(before=0, after=0) == 0.0
+
+    @pytest.mark.unit
+    def test_findings_per_1k_tokens(self) -> None:
+        assert findings_per_1k_tokens(count=20, tokens=4000) == pytest.approx(5.0)
+
+    @pytest.mark.unit
+    def test_findings_per_1k_tokens_zero_tokens_is_zero(self) -> None:
+        assert findings_per_1k_tokens(count=5, tokens=0) == 0.0

--- a/plugins/tome/tests/metrics/test_harness.py
+++ b/plugins/tome/tests/metrics/test_harness.py
@@ -1,0 +1,76 @@
+"""
+Feature: retrieval-metrics benchmark harness (make metrics)
+
+As a maintainer
+I want one command that scores a committed gold set offline
+So that relevancy is measurable and trend-able with no network or model.
+"""
+
+from __future__ import annotations
+
+import pytest
+from tome.metrics.harness import (
+    GoldItem,
+    RetrievalReport,
+    evaluate,
+    load_gold_set,
+    main,
+)
+
+
+class TestLoadGoldSet:
+    @pytest.mark.unit
+    def test_loads_committed_fixture(self) -> None:
+        """The shipped fixture parses into GoldItems."""
+        gold = load_gold_set()
+        assert len(gold) >= 1
+        assert all(isinstance(item, GoldItem) for item in gold)
+        assert all(item.topic and item.ranked_ids for item in gold)
+
+
+class TestEvaluate:
+    @pytest.mark.unit
+    def test_means_match_hand_computed(self) -> None:
+        gold = [GoldItem("t", ["a", "b", "c"], frozenset({"a", "c"}))]
+        report = evaluate(gold, k=3)
+        # nDCG = 1.5 / 1.6309 = 0.9197; MRR = 1.0; recall = 1.0
+        assert report.mean_ndcg == pytest.approx(0.9197, abs=1e-3)
+        assert report.mean_mrr == pytest.approx(1.0)
+        assert report.mean_recall == pytest.approx(1.0)
+        assert report.n_topics == 1
+
+    @pytest.mark.unit
+    def test_averages_across_topics(self) -> None:
+        gold = [
+            GoldItem("t1", ["a"], frozenset({"a"})),  # perfect: ndcg 1
+            GoldItem("t2", ["x", "y"], frozenset({"y"})),  # miss-then-hit
+        ]
+        report = evaluate(gold, k=2)
+        assert 0.0 < report.mean_ndcg < 1.0
+        assert report.n_topics == 2
+
+    @pytest.mark.unit
+    def test_empty_gold_is_zero(self) -> None:
+        report = evaluate([], k=10)
+        assert report.n_topics == 0
+        assert report.mean_ndcg == 0.0
+
+
+class TestReportRender:
+    @pytest.mark.unit
+    def test_render_shows_metric_names_and_values(self) -> None:
+        report = RetrievalReport(
+            k=10, n_topics=3, mean_ndcg=0.5, mean_mrr=0.6, mean_recall=0.7
+        )
+        text = report.render()
+        assert "nDCG" in text
+        assert "0.500" in text
+        assert "MRR" in text
+
+
+class TestMain:
+    @pytest.mark.unit
+    def test_main_prints_report(self, capsys: pytest.CaptureFixture[str]) -> None:
+        main()
+        out = capsys.readouterr().out
+        assert "nDCG" in out

--- a/plugins/tome/tests/metrics/test_impact.py
+++ b/plugins/tome/tests/metrics/test_impact.py
@@ -1,0 +1,95 @@
+"""
+Feature: impact metrics (impact dimension)
+
+As the tome research engine
+I want disruption and centrality measured over the citation graph
+So that a paper's structural influence is quantified, with the
+citation-inflation bias designed out of cross-cohort comparison.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from tome.graph.palace_adapter import CitationGraphWriter
+from tome.metrics.impact import (
+    Cohort,
+    DisruptionScore,
+    assert_comparable,
+    disruption_index,
+    rank_by_centrality,
+)
+from tome.models import CitationEdge
+
+
+class TestDisruptionIndex:
+    @pytest.mark.unit
+    def test_fully_disruptive(self) -> None:
+        # Citing papers ignore the focal's references entirely.
+        assert disruption_index({"A", "B"}, set()) == pytest.approx(1.0)
+
+    @pytest.mark.unit
+    def test_fully_consolidating(self) -> None:
+        # Every citing paper also cites the focal's references.
+        assert disruption_index({"A", "B"}, {"A", "B"}) == pytest.approx(-1.0)
+
+    @pytest.mark.unit
+    def test_mixed_case(self) -> None:
+        # only_focal={A}=1, both={B,C}=2, only_refs={D}=1 -> (1-2)/4 = -0.25
+        assert disruption_index({"A", "B", "C"}, {"B", "C", "D"}) == pytest.approx(
+            -0.25
+        )
+
+    @pytest.mark.unit
+    def test_no_citations_is_zero(self) -> None:
+        assert disruption_index(set(), set()) == 0.0
+
+
+class TestCohortGuardrail:
+    @pytest.mark.unit
+    def test_same_cohort_is_comparable(self) -> None:
+        a = DisruptionScore("P1", 0.3, Cohort("cs.LG", 2024))
+        b = DisruptionScore("P2", -0.1, Cohort("cs.LG", 2024))
+        assert_comparable(a, b)  # must not raise
+
+    @pytest.mark.unit
+    def test_cross_field_raises(self) -> None:
+        a = DisruptionScore("P1", 0.3, Cohort("cs.LG", 2024))
+        b = DisruptionScore("P2", 0.3, Cohort("q-bio", 2024))
+        with pytest.raises(ValueError, match="cohort"):
+            assert_comparable(a, b)
+
+    @pytest.mark.unit
+    def test_cross_year_raises(self) -> None:
+        a = DisruptionScore("P1", 0.3, Cohort("cs.LG", 2010))
+        b = DisruptionScore("P2", 0.3, Cohort("cs.LG", 2024))
+        with pytest.raises(ValueError, match="cohort"):
+            assert_comparable(a, b)
+
+
+class TestCentrality:
+    @pytest.mark.unit
+    def test_ranks_descending_by_pagerank(self) -> None:
+        ranked = rank_by_centrality({"A": 0.1, "B": 0.5, "C": 0.3})
+        assert [pid for pid, _ in ranked] == ["B", "C", "A"]
+
+    @pytest.mark.unit
+    def test_empty_is_empty(self) -> None:
+        assert rank_by_centrality({}) == []
+
+
+class TestCentralityContract:
+    """Runs only where memory-palace is installed (combined CI)."""
+
+    @pytest.mark.integration
+    def test_pagerank_feeds_centrality(self, tmp_path: Any) -> None:
+        mp = pytest.importorskip("memory_palace")
+        graph = mp.KnowledgeGraph(str(tmp_path / "g.db"))
+        CitationGraphWriter(graph).write_edges(
+            [CitationEdge("P1", "P2"), CitationEdge("P3", "P2")]
+        )
+        analyzer = mp.PalaceGraphAnalyzer(graph)
+        ranked = rank_by_centrality(analyzer.pagerank())
+
+        assert isinstance(ranked, list)

--- a/plugins/tome/tests/metrics/test_retrieval.py
+++ b/plugins/tome/tests/metrics/test_retrieval.py
@@ -1,0 +1,59 @@
+"""
+Feature: retrieval-quality metrics (build increment 5)
+
+As the tome research engine
+I want deterministic nDCG / MRR / recall against a gold set
+So that relevancy is measured with the trustworthy IR yardstick,
+not an LLM judge.
+"""
+
+from __future__ import annotations
+
+import pytest
+from tome.metrics.retrieval import mrr, ndcg_at_k, recall_at_k
+
+RANKED = ["a", "b", "c", "d"]
+RELEVANT = {"a", "c"}
+
+
+class TestNdcg:
+    @pytest.mark.unit
+    def test_ndcg_matches_hand_computed_value(self) -> None:
+        # DCG = 1/log2(2) + 1/log2(4) = 1.5; IDCG = 1 + 1/log2(3) = 1.6309
+        assert ndcg_at_k(RANKED, RELEVANT, k=4) == pytest.approx(0.9197, abs=1e-3)
+
+    @pytest.mark.unit
+    def test_perfect_ranking_scores_one(self) -> None:
+        assert ndcg_at_k(["a", "c", "b"], {"a", "c"}, k=3) == pytest.approx(1.0)
+
+    @pytest.mark.unit
+    def test_no_relevant_items_scores_zero(self) -> None:
+        assert ndcg_at_k(RANKED, set(), k=4) == 0.0
+
+
+class TestMrr:
+    @pytest.mark.unit
+    def test_first_relevant_at_rank_one(self) -> None:
+        assert mrr(RANKED, RELEVANT) == pytest.approx(1.0)
+
+    @pytest.mark.unit
+    def test_first_relevant_at_rank_three(self) -> None:
+        assert mrr(["x", "y", "a"], {"a"}) == pytest.approx(1 / 3)
+
+    @pytest.mark.unit
+    def test_no_relevant_scores_zero(self) -> None:
+        assert mrr(RANKED, {"z"}) == 0.0
+
+
+class TestRecall:
+    @pytest.mark.unit
+    def test_recall_at_2(self) -> None:
+        assert recall_at_k(RANKED, RELEVANT, k=2) == pytest.approx(0.5)
+
+    @pytest.mark.unit
+    def test_recall_at_4_is_full(self) -> None:
+        assert recall_at_k(RANKED, RELEVANT, k=4) == pytest.approx(1.0)
+
+    @pytest.mark.unit
+    def test_recall_empty_relevant_is_zero(self) -> None:
+        assert recall_at_k(RANKED, set(), k=4) == 0.0

--- a/plugins/tome/tests/retrieval/test_semantic.py
+++ b/plugins/tome/tests/retrieval/test_semantic.py
@@ -9,12 +9,14 @@ reusing memory-palace's EmbeddingIndex (hash fallback, no hard deps).
 
 from __future__ import annotations
 
+import importlib.util
 from typing import Any
 
 import pytest
 from tome.retrieval.semantic import (
     Embedder,
     SemanticRetriever,
+    best_available_provider,
     embedder_available,
     open_embedder,
 )
@@ -89,3 +91,38 @@ class TestRealEmbedderContract:
 
         assert len(ranked) == 2
         assert {f.title for f in ranked} == {f.title for f in findings}
+
+
+class TestProviderSelection:
+    @pytest.mark.unit
+    def test_best_available_provider_is_valid(self) -> None:
+        """Auto-selection returns a provider EmbeddingIndex understands."""
+        assert best_available_provider() in {"none", "local"}
+
+    @pytest.mark.unit
+    def test_falls_back_to_hash_without_sentence_transformers(self) -> None:
+        """
+        Given sentence-transformers is not installed (tome's isolated venv)
+        Then the auto-selected provider is the hash fallback
+        """
+        if importlib.util.find_spec("sentence_transformers") is not None:
+            pytest.skip("sentence-transformers installed; cannot test fallback")
+        assert best_available_provider() == "none"
+
+
+class TestProviderPlumbing:
+    """Runs only where memory-palace is installed (combined CI)."""
+
+    @pytest.mark.integration
+    def test_provider_is_passed_to_backend(self, tmp_path: Any) -> None:
+        pytest.importorskip("memory_palace")
+        embedder: Any = open_embedder(str(tmp_path / "e.yaml"), provider="local")
+
+        assert embedder.requested_provider == "local"
+
+    @pytest.mark.integration
+    def test_default_provider_is_hash(self, tmp_path: Any) -> None:
+        pytest.importorskip("memory_palace")
+        embedder: Any = open_embedder(str(tmp_path / "e2.yaml"))
+
+        assert embedder.requested_provider == "none"

--- a/plugins/tome/tests/retrieval/test_semantic.py
+++ b/plugins/tome/tests/retrieval/test_semantic.py
@@ -1,0 +1,91 @@
+"""
+Feature: semantic retrieval over findings (build increment 4)
+
+As the tome research engine
+I want findings ranked by embedding similarity to the query
+So that relevant results surface even without lexical overlap,
+reusing memory-palace's EmbeddingIndex (hash fallback, no hard deps).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from tome.retrieval.semantic import (
+    Embedder,
+    SemanticRetriever,
+    embedder_available,
+    open_embedder,
+)
+
+from tests.factories import make_finding
+
+
+class FakeEmbedder:
+    """Deterministic embedder: 'match' texts align with 'match' queries."""
+
+    def vectorize(self, text: str) -> list[float]:
+        return [1.0, 0.0] if "match" in text else [0.0, 1.0]
+
+
+class TestSemanticRetriever:
+    @pytest.mark.unit
+    def test_ranks_similar_findings_first(self) -> None:
+        """
+        Given a query and one matching, one non-matching finding
+        When ranked semantically
+        Then the matching finding comes first
+        """
+        retriever = SemanticRetriever(FakeEmbedder())
+        hit = make_finding(0.5, title="match topic", summary="about match")
+        miss = make_finding(0.5, title="unrelated", summary="other subject")
+
+        ranked = retriever.rank("match", [miss, hit])
+
+        assert ranked[0] is hit
+        assert ranked[1] is miss
+
+    @pytest.mark.unit
+    def test_top_k_limits_results(self) -> None:
+        retriever = SemanticRetriever(FakeEmbedder())
+        findings = [make_finding(0.5, title=f"match {i}") for i in range(4)]
+
+        assert len(retriever.rank("match", findings, top_k=2)) == 2
+
+    @pytest.mark.unit
+    def test_empty_findings_returns_empty(self) -> None:
+        retriever = SemanticRetriever(FakeEmbedder())
+        assert retriever.rank("match", []) == []
+
+    @pytest.mark.unit
+    def test_fake_satisfies_protocol(self) -> None:
+        assert isinstance(FakeEmbedder(), Embedder)
+
+
+class TestOpenEmbedder:
+    @pytest.mark.unit
+    def test_raises_explicitly_when_absent(self) -> None:
+        if embedder_available():
+            pytest.skip("memory-palace installed; cannot test absent path")
+        with pytest.raises(Exception, match="memory-palace"):
+            open_embedder("/tmp/tome-emb.yaml")
+
+
+class TestRealEmbedderContract:
+    """Runs only where memory-palace is installed (combined CI)."""
+
+    @pytest.mark.integration
+    def test_real_embedding_index_ranks(self, tmp_path: Any) -> None:
+        pytest.importorskip("memory_palace")
+        embedder = open_embedder(str(tmp_path / "emb.yaml"))
+        retriever = SemanticRetriever(embedder)
+
+        findings = [
+            make_finding(0.5, title="graph neural networks", summary="gnn"),
+            make_finding(0.5, title="baking sourdough bread", summary="yeast"),
+        ]
+        ranked = retriever.rank("graph neural networks", findings, top_k=2)
+
+        assert len(ranked) == 2
+        assert {f.title for f in ranked} == {f.title for f in findings}

--- a/plugins/tome/tests/unit/test_ranker.py
+++ b/plugins/tome/tests/unit/test_ranker.py
@@ -12,7 +12,12 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 import pytest
-from tome.synthesis.ranker import compute_relevance_score, group_by_theme, rank_findings
+from tome.synthesis.ranker import (
+    compute_ranked_score,
+    compute_relevance_score,
+    group_by_theme,
+    rank_findings,
+)
 
 from tests.factories import make_finding
 
@@ -330,3 +335,48 @@ class TestGroupByTheme:
             metadata={"citations": 201},
         )
         assert compute_relevance_score(f) == pytest.approx(0.8)
+
+
+class TestTriangulationWiring:
+    """
+    Feature: cross-channel triangulation feeds ranking (increment 3)
+
+    As a synthesis pipeline
+    I want corroborated findings to outrank equally-relevant lone findings
+    So that agreement across channels is rewarded in the final order.
+    """
+
+    @pytest.mark.unit
+    def test_ranked_score_adds_triangulation_bonus(self) -> None:
+        """
+        Given a finding corroborated by another channel
+        When compute_ranked_score is computed with the full set
+        Then it exceeds the plain relevance score
+        """
+        target = make_finding(0.5, channel="code", title="graph rag retrieval")
+        corroborator = make_finding(
+            0.5, source="arxiv", channel="academic", title="graph rag retrieval"
+        )
+        findings = [target, corroborator]
+
+        ranked = compute_ranked_score(target, findings)
+
+        assert ranked > compute_relevance_score(target)
+
+    @pytest.mark.unit
+    def test_corroborated_finding_outranks_lone_peer(self) -> None:
+        """
+        Given two equally-relevant findings, one corroborated cross-channel
+        When rank_findings orders them
+        Then the corroborated one comes first
+        """
+        corroborated = make_finding(0.5, channel="code", title="vector search index")
+        cross = make_finding(
+            0.5, source="arxiv", channel="academic", title="vector search index"
+        )
+        lone = make_finding(0.5, channel="discourse", title="unrelated topic entirely")
+
+        result = rank_findings([lone, corroborated, cross])
+
+        assert result[0] is corroborated or result[0] is cross
+        assert result.index(lone) > 0


### PR DESCRIPTION
## What and why

Turns `tome` from a flat-list research **aggregator** into a
graph-backed research **engine**: it keeps the citation edges it already
fetched and threw away, links them into a knowledge graph, surfaces
common threads and further research paths, ranks semantically, and ships
a deterministic research-quality metrics harness.

The work started from a deep-research pass (dogfooding `tome` across
academic, code, discourse, and TRIZ channels). The evidence pointed to
**reuse and restraint over building**: the knowledge graph, community
detection, link prediction, and embeddings the goal needs already exist
in `memory-palace`; `tome` just never fed them. Full write-up in
`docs/tome-research-engine/`.

## The load-bearing decision

The knowledge graph lives in `memory-palace` (`KnowledgeGraph` +
`PalaceGraphAnalyzer`), not in a new `tome` store or an LLM-constructed
one. A war-room review (`docs/plans/2026-07-17-war-room-tome-graph-decision.md`)
hardened this: consume a **public API** (promoted to `memory_palace.__all__`),
fail with an **explicit capability error** rather than a silent no-op,
and pin the coupling behind one adapter seam with a contract test.
LLM graph construction was rejected as the top reported failure mode
(hallucinated edges); a `tome`-native graph was rejected as speculative
duplication.

## What changed

Seven build increments, each its own commit with tests:

| Area | Change |
|------|--------|
| Ingest | `CitationEdge` + `parse_citation_edges`: keep the citation edges `academic.py` used to discard |
| Graph | `tome/graph/palace_adapter`: write papers+edges into `KnowledgeGraph` via a `GraphWriter` protocol |
| Threads/paths | `tome/graph/threads`: `common_threads()` (community detection) + `research_paths()` (Adamic-Adar link prediction); wired the dormant triangulation bonus into ranking |
| Retrieval | `tome/retrieval/semantic`: cosine ranking over `EmbeddingIndex`; `best_available_provider()` auto-selects sentence-transformers when installed |
| Metrics | `tome/metrics`: nDCG/MRR/recall (relevancy), diversity/efficiency (creativity/performance), disruption index + centrality (impact), and a `make metrics` harness over a committed gold set |

`memory-palace` changes are additive: three classes promoted to the
public `__all__` (`KnowledgeGraph`, `PalaceGraphAnalyzer`,
`EmbeddingIndex`) so `tome` consumes a supported surface.

## Evidence

- **tome: 592 passed, 6 skipped**; **memory-palace: 1107 passed** (the
  public-API promotions broke nothing).
- **All 6 cross-plugin contract tests pass** against the real
  `memory-palace` backend in a combined env; they `importorskip` in
  tome's isolated venv.
- Every commit passed the full strict gate: mypy across all plugins +
  both test suites via pre-commit.
- `make metrics` prints a reproducible offline table (nDCG@10 0.690,
  MRR 0.611, recall@10 1.000 on the shipped fixture).

## Honest limitations (surfaced by proof-of-work, not hidden)

1. **Semantic retrieval is not semantic with zero dependencies.** The
   `provider="none"` hash fallback is deterministic but not semantic; a
   composed end-to-end run mis-ranked an unrelated result. The provider
   wiring is verified, but real quality requires installing
   sentence-transformers. Not benchmarked here (needs the model
   download).
2. **`make metrics` benchmarks only the relevancy dimension.** The other
   dimensions' functions exist and are tested, but folding them into the
   one command honestly needs a richer fixture (channels, token counts,
   citation sets) rather than fabricated numbers.
3. **Impact metrics are computed but disruption is guarded, not
   normalized end-to-end.** `assert_comparable` refuses cross-cohort
   comparison in code (the disruption index is biased by citation
   inflation); full field-normalization is a follow-on.

## Scope note

The branch is large (34 files, +2046/−8) because it spans research,
design docs, two plugins, and seven feature increments. It is organized
as a clean per-increment commit history for review. Reviewers may prefer
to read commit-by-commit.

## Test plan

- `cd plugins/tome && make test` (592 passed)
- `cd plugins/memory-palace && make test` (1107 passed)
- Combined contracts: `cd plugins/tome && PYTHONPATH=../memory-palace/src uv run --with networkx --with numpy --with scipy pytest -m integration`
- `cd plugins/tome && make metrics`
