### PR TITLE
fix(abstract): distinguish missing signal from clean results in LEARNINGS.md

### DIFF
--- a/plugins/abstract/scripts/aggregate_skill_logs.py
+++ b/plugins/abstract/scripts/aggregate_skill_logs.py
@@ -16,7 +16,7 @@ import json
 import statistics
 import sys
 from collections import Counter, defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -48,6 +48,12 @@ LOW_RATING_THRESHOLD = 3.0  # Ratings below this need attention
 EXCESSIVE_FAILURES_THRESHOLD = 10  # Total failures above this is concerning
 SLOW_EXECUTION_THRESHOLD_MS = 10000  # 10 seconds
 LOW_USER_RATING_THRESHOLD = 3.5  # For detection in aggregate view
+
+# duration_ms is measured between the PreToolUse and PostToolUse hooks on the
+# Skill tool, which brackets loading SKILL.md rather than the work the skill
+# goes on to perform over the turns that follow. Averages below this floor are
+# dispatch-bound: accurate for what they measure, but not a measure of work.
+DISPATCH_BOUND_DURATION_MS = 250
 
 
 @dataclass
@@ -81,6 +87,8 @@ class AggregationResult:
     slow_skills: list[dict[str, Any]]
     low_rated_skills: list[dict[str, Any]]
     metrics_by_skill: dict[str, SkillLogSummary]
+    rated_executions: int = 0
+    dispatch_bound_skills: list[str] = field(default_factory=list)
 
 
 def get_learnings_path() -> Path:
@@ -410,6 +418,20 @@ def aggregate_logs(days_back: int = 30) -> AggregationResult:
     # Calculate totals
     total_executions = sum(m.total_executions for m in metrics_by_skill.values())
 
+    # Signal coverage: which detectors received usable input this period
+    rated_executions = sum(
+        1
+        for entries in entries_by_skill.values()
+        for entry in entries
+        if entry.get("qualitative_evaluation") is not None
+    )
+    dispatch_bound_skills = sorted(
+        skill
+        for skill, metrics in metrics_by_skill.items()
+        if metrics.total_executions > 0
+        and metrics.avg_duration_ms < DISPATCH_BOUND_DURATION_MS
+    )
+
     return AggregationResult(
         timestamp=datetime.now(timezone.utc),
         skills_analyzed=len(metrics_by_skill),
@@ -418,7 +440,60 @@ def aggregate_logs(days_back: int = 30) -> AggregationResult:
         slow_skills=slow_skills,
         low_rated_skills=low_rated_skills,
         metrics_by_skill=metrics_by_skill,
+        rated_executions=rated_executions,
+        dispatch_bound_skills=dispatch_bound_skills,
     )
+
+
+def format_signal_coverage(result: AggregationResult) -> list[str]:
+    """Format what the detectors in this report could and could not see.
+
+    A detector that never receives usable input produces the same empty
+    output as a detector that looked and found nothing wrong. This section
+    keeps the two apart, so a report generated from missing signal is not
+    read as a clean bill of health.
+
+    Args:
+        result: Aggregation result
+
+    Returns:
+        Lines for the Signal Coverage section
+
+    """
+    lines = ["## Signal Coverage", ""]
+
+    if result.rated_executions == 0:
+        lines.append(
+            f"- **User ratings**: not measured. 0 of {result.total_executions} "
+            "executions carry a `qualitative_evaluation`, which is written only "
+            "by `/evaluate-skill` or the `skill-evaluator` agent. The low-rating "
+            "detectors did not run, so an empty Low User Ratings section below "
+            "is not evidence that ratings are good."
+        )
+    else:
+        lines.append(
+            f"- **User ratings**: {result.rated_executions} of "
+            f"{result.total_executions} executions carry an evaluation."
+        )
+
+    if result.dispatch_bound_skills:
+        lines.append(
+            f"- **Durations**: {len(result.dispatch_bound_skills)} of "
+            f"{result.skills_analyzed} skills average under "
+            f"{DISPATCH_BOUND_DURATION_MS}ms. `duration_ms` spans the PreToolUse "
+            "to PostToolUse window on the Skill tool, which brackets loading "
+            "SKILL.md rather than the work the skill performs over the turns "
+            "that follow. The slow-execution detector "
+            f"({SLOW_EXECUTION_THRESHOLD_MS // 1000}s threshold) cannot fire on "
+            "these values."
+        )
+    else:
+        lines.append(
+            f"- **Durations**: no skill averages under {DISPATCH_BOUND_DURATION_MS}ms."
+        )
+
+    lines.extend(["", "---", ""])
+    return lines
 
 
 def format_high_impact_issues(issues: list[dict[str, Any]]) -> list[str]:
@@ -657,15 +732,42 @@ def generate_learnings_md(result: AggregationResult, existing_pinned: str = "") 
         lines.append("")
         lines.extend(["---", ""])
 
+    # Coverage first: it qualifies how every section below should be read
+    lines.extend(format_signal_coverage(result))
+
     # Add sections using helper functions
     if result.high_impact_issues:
         lines.extend(format_high_impact_issues(result.high_impact_issues))
 
     if result.slow_skills:
         lines.extend(format_slow_skills(result.slow_skills))
+    elif result.dispatch_bound_skills:
+        lines.extend(
+            [
+                "## Slow Execution",
+                "",
+                "Not measured this period: every duration sample is "
+                "dispatch-bound (see Signal Coverage).",
+                "",
+                "---",
+                "",
+            ]
+        )
 
     if result.low_rated_skills:
         lines.extend(format_low_rated_skills(result.low_rated_skills))
+    elif result.rated_executions == 0:
+        lines.extend(
+            [
+                "## Low User Ratings",
+                "",
+                "Not measured this period: no execution carries a qualitative "
+                "evaluation (see Signal Coverage).",
+                "",
+                "---",
+                "",
+            ]
+        )
 
     # Skill performance summary
     lines.extend(format_skill_summary(result.metrics_by_skill))

--- a/plugins/abstract/tests/scripts/test_aggregate_skill_logs.py
+++ b/plugins/abstract/tests/scripts/test_aggregate_skill_logs.py
@@ -31,6 +31,7 @@ from aggregate_skill_logs import (
     detect_slow_skills,
     format_high_impact_issues,
     format_low_rated_skills,
+    format_signal_coverage,
     format_skill_summary,
     format_slow_skills,
     generate_learnings_md,
@@ -858,6 +859,90 @@ class TestFormatSkillSummary:
 
 
 # ---------------------------------------------------------------------------
+# Tests: format_signal_coverage
+# ---------------------------------------------------------------------------
+
+
+def _make_result(  # noqa: PLR0913 - test factory mirrors AggregationResult fields for flexible fixture creation
+    *,
+    skills_analyzed: int = 1,
+    total_executions: int = 10,
+    rated_executions: int = 0,
+    dispatch_bound_skills: list[str] | None = None,
+    slow_skills: list[dict] | None = None,
+    low_rated_skills: list[dict] | None = None,
+) -> AggregationResult:
+    return AggregationResult(
+        timestamp=datetime.now(timezone.utc),
+        skills_analyzed=skills_analyzed,
+        total_executions=total_executions,
+        high_impact_issues=[],
+        slow_skills=slow_skills or [],
+        low_rated_skills=low_rated_skills or [],
+        metrics_by_skill={},
+        rated_executions=rated_executions,
+        dispatch_bound_skills=dispatch_bound_skills or [],
+    )
+
+
+class TestFormatSignalCoverage:
+    """Test format_signal_coverage separates missing signal from clean data."""
+
+    @pytest.mark.unit
+    def test_zero_rated_executions_marked_not_measured(self) -> None:
+        """Scenario: no execution carries a qualitative evaluation.
+        Given an aggregation over 108 executions with 0 rated
+        When format_signal_coverage is called
+        Then the ratings line reports it as not measured
+        """
+        lines = format_signal_coverage(
+            _make_result(skills_analyzed=32, total_executions=108)
+        )
+        text = "\n".join(lines)
+        assert "Signal Coverage" in text
+        assert "not measured" in text
+        assert "0 of 108" in text
+
+    @pytest.mark.unit
+    def test_rated_executions_reported_as_coverage(self) -> None:
+        """Scenario: some executions carry evaluations.
+        Given 5 of 20 executions rated
+        When format_signal_coverage is called
+        Then the ratings line reports the coverage instead of a warning
+        """
+        lines = format_signal_coverage(
+            _make_result(total_executions=20, rated_executions=5)
+        )
+        text = "\n".join(lines)
+        assert "5 of 20 executions carry an evaluation" in text
+        assert "not measured" not in text
+
+    @pytest.mark.unit
+    def test_dispatch_bound_skills_explain_dead_slow_detector(self) -> None:
+        """Scenario: every duration sample is dispatch-bound.
+        Given 2 of 3 skills averaging under the dispatch floor
+        When format_signal_coverage is called
+        Then the durations line states the slow detector cannot fire
+        """
+        lines = format_signal_coverage(
+            _make_result(skills_analyzed=3, dispatch_bound_skills=["p:fast", "p:quick"])
+        )
+        text = "\n".join(lines)
+        assert "2 of 3 skills" in text
+        assert "cannot fire" in text
+
+    @pytest.mark.unit
+    def test_no_dispatch_bound_skills_reports_durations_usable(self) -> None:
+        """Scenario: all durations are above the dispatch floor.
+        Given no dispatch-bound skills
+        When format_signal_coverage is called
+        Then the durations line makes no claim about a dead detector
+        """
+        text = "\n".join(format_signal_coverage(_make_result()))
+        assert "cannot fire" not in text
+
+
+# ---------------------------------------------------------------------------
 # Tests: generate_learnings_md
 # ---------------------------------------------------------------------------
 
@@ -961,6 +1046,38 @@ class TestGenerateLearningsMd:
         content = generate_learnings_md(result)
         assert "Low User Ratings" in content
 
+    @pytest.mark.unit
+    def test_unrated_period_renders_explicit_not_measured_section(self) -> None:
+        """Scenario: ratings absent rather than good.
+        Given zero rated executions and no low-rated skills
+        When generate_learnings_md is called
+        Then Low User Ratings appears and states it was not measured
+        """
+        content = generate_learnings_md(_make_result(rated_executions=0))
+        assert "Low User Ratings" in content
+        assert "Not measured this period" in content
+
+    @pytest.mark.unit
+    def test_dispatch_bound_period_renders_explicit_slow_section(self) -> None:
+        """Scenario: durations too short to feed the slow detector.
+        Given dispatch-bound skills and no slow skills
+        When generate_learnings_md is called
+        Then Slow Execution appears and states it was not measured
+        """
+        content = generate_learnings_md(_make_result(dispatch_bound_skills=["p:fast"]))
+        assert "Slow Execution" in content
+        assert "dispatch-bound" in content
+
+    @pytest.mark.unit
+    def test_coverage_section_always_present(self) -> None:
+        """Scenario: every report states what it could see.
+        Given any aggregation result
+        When generate_learnings_md is called
+        Then the Signal Coverage section is included
+        """
+        content = generate_learnings_md(_make_result())
+        assert "Signal Coverage" in content
+
 
 # ---------------------------------------------------------------------------
 # Tests: aggregate_logs
@@ -1018,6 +1135,72 @@ class TestAggregateLogs:
         mock_get_log_dir.assert_called_once()
         assert result.skills_analyzed == 1
         assert result.total_executions == 10
+
+    @pytest.mark.unit
+    def test_aggregate_logs_counts_rated_executions(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Scenario: only some executions carry an evaluation.
+        Given 2 rated entries and 3 unrated entries
+        When aggregate_logs is called
+        Then rated_executions is 2
+        """
+        skill_dir = tmp_path / "my-plugin" / "my-skill"
+        skill_dir.mkdir(parents=True)
+
+        entries = [_make_entry(rating=4.0) for _ in range(2)] + [
+            _make_entry() for _ in range(3)
+        ]
+        (skill_dir / "log.jsonl").write_text("\n".join(json.dumps(e) for e in entries))
+        monkeypatch.setattr(
+            "aggregate_skill_logs.get_log_directory", Mock(return_value=tmp_path)
+        )
+
+        result = aggregate_logs(days_back=30)
+        assert result.rated_executions == 2
+
+    @pytest.mark.unit
+    def test_aggregate_logs_flags_dispatch_bound_skill(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Scenario: a skill's durations only cover dispatch.
+        Given entries averaging 100ms, below the dispatch floor
+        When aggregate_logs is called
+        Then the skill is listed in dispatch_bound_skills
+        """
+        skill_dir = tmp_path / "my-plugin" / "my-skill"
+        skill_dir.mkdir(parents=True)
+
+        entries = [_make_entry(duration_ms=100) for _ in range(4)]
+        (skill_dir / "log.jsonl").write_text("\n".join(json.dumps(e) for e in entries))
+        monkeypatch.setattr(
+            "aggregate_skill_logs.get_log_directory", Mock(return_value=tmp_path)
+        )
+
+        result = aggregate_logs(days_back=30)
+        assert result.dispatch_bound_skills == ["my-plugin:my-skill"]
+        assert result.slow_skills == []
+
+    @pytest.mark.unit
+    def test_aggregate_logs_does_not_flag_real_durations(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Scenario: durations plausibly cover real work.
+        Given entries averaging 4000ms
+        When aggregate_logs is called
+        Then dispatch_bound_skills is empty
+        """
+        skill_dir = tmp_path / "my-plugin" / "my-skill"
+        skill_dir.mkdir(parents=True)
+
+        entries = [_make_entry(duration_ms=4000) for _ in range(4)]
+        (skill_dir / "log.jsonl").write_text("\n".join(json.dumps(e) for e in entries))
+        monkeypatch.setattr(
+            "aggregate_skill_logs.get_log_directory", Mock(return_value=tmp_path)
+        )
+
+        result = aggregate_logs(days_back=30)
+        assert result.dispatch_bound_skills == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Reason

`generate_learnings_md` skips the ratings and slow-execution sections when their
lists are empty. A detector that never received usable input therefore produces
exactly the same report as a detector that looked and found nothing wrong, and
the summary closes with "No high-priority actions this period". That reads as a
clean bill of health rather than as an empty instrument.

Two inputs are structurally absent during normal operation:

* `qualitative_evaluation` is written as `None` by `skill_execution_logger.py`
  and populated only by `/evaluate-skill` or the `skill-evaluator` agent. Both
  rating detectors (`detect_low_rated_skills`, and the `low_rating` branch of
  `detect_high_impact_issues`) stay idle unless someone runs the evaluation by
  hand. The `Rating: N/A` column across every row of recent auto-posted reports
  suggests that is the steady state.
* `duration_ms` is the interval between `pre_skill_execution.py` (PreToolUse) and
  `skill_execution_logger.py` (PostToolUse) on the `Skill` tool. That window
  brackets loading SKILL.md, not the work the skill goes on to perform over the
  turns that follow. Averages land around 0.1s, well below
  `SLOW_EXECUTION_THRESHOLD_MS` (10000), so `detect_slow_skills` cannot fire.

## Changes

* `scripts/aggregate_skill_logs.py`: add `DISPATCH_BOUND_DURATION_MS` (250ms) as
  the floor below which an average duration reflects dispatch rather than work;
  add `rated_executions` and `dispatch_bound_skills` to `AggregationResult`
  (both defaulted, so existing constructions are unaffected); compute them in
  `aggregate_logs`; add `format_signal_coverage` and always emit it; render
  explicit "not measured" blocks where the ratings and slow-execution sections
  were previously omitted in silence.
* `tests/scripts/test_aggregate_skill_logs.py`: 11 new tests covering the
  coverage section in both the measured and unmeasured cases, the explicit
  not-measured sections in `generate_learnings_md`, and the two new fields end
  to end through `aggregate_logs`.

No detector thresholds, log schema, or aggregation semantics change. The logger
is untouched.

## Not in scope

Measuring the actual duration of skill work. The work spans the turns after the
`Skill` call returns, so capturing it needs instrumentation at a different point
in the lifecycle. That is a design decision rather than a patch. This PR only
stops the report from presenting absent signal as a clean result.

## Checks

* `python3 -m pytest tests/scripts/test_aggregate_skill_logs.py`: 76 passed
  (11 new).
* `python3 -m pytest tests/`: 2305 passed, 2 failed. Both failures
  (`test_rules_validator.py::TestEvaluateRulesDirectory::test_unreadable_file_in_evaluation`
  and `TestValidateFrontmatterUnreadable::test_unreadable_file_returns_error`)
  reproduce identically on a clean `master` checkout in this environment, where
  the process runs as root and chmod-based unreadable-file fixtures do not take
  effect. Unrelated to this change.
* `python3 -m ruff check` on both changed files: 2 errors, the same two
  pre-existing `PLR0917` hits on the test helpers that are present on `master`.
  No new errors introduced.
* `python3 -m ruff format --check` on both changed files, already formatted.