### PR TITLE
docs: update retired model id in the SDK integration example

### DIFF
--- a/docs/guides/skills-separation-quickref.md
+++ b/docs/guides/skills-separation-quickref.md
@@ -81,7 +81,7 @@ class MyAgent:
 
     def chat(self, message: str):
         return self.client.messages.create(
-            model="claude-3-5-sonnet-20241022",
+            model="claude-sonnet-4-6",
             system=self.system_prompt,  # ← Runtime skills here
             messages=[{"role": "user", "content": message}]
         )


### PR DESCRIPTION
One line in `docs/guides/skills-separation-quickref.md`. The SDK example under "SDK Integration" passes `claude-3-5-sonnet-20241022` to `messages.create`, and that id reached its retirement date on 28 October 2025.

| File | Line | Was | Now |
| --- | --- | --- | --- |
| `docs/guides/skills-separation-quickref.md` | 84 | `claude-3-5-sonnet-20241022` | `claude-sonnet-4-6` |

Retirement dates are listed at https://platform.claude.com/docs/en/about-claude/model-deprecations. I picked `claude-sonnet-4-6` because it is the current Sonnet and the snippet is a plain text completion, so nothing in it depends on a specific generation. If you would rather point readers at Opus or Haiku, or at an alias, say so and I will change it.

Two other places name older ids and I left both alone on purpose:

`plugins/abstract/docs/compatibility/compatibility-features-march2026-early.md` line 254 reads "updated from `claude-sonnet-4-20250514`". That sentence records what the value used to be, so rewriting it would make the history wrong.

The rest of the repository already uses current ids, including the `claude-sonnet-4-6` and `claude-opus-4-8` references across the plugins.

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model ids, so I am saying that up front rather than leaving you to wonder. I have not called the API with the old id to reproduce a failure, the claim rests on the published retirement date. If you would rather handle this your own way, or would rather not get this kind of contribution at all, tell me and I will not send another.
