### PR TITLE
fix(abstract): an execution nothing timed was logged as a real 0ms

### DIFF
--- a/plugins/abstract/hooks/skill_execution_logger.py
+++ b/plugins/abstract/hooks/skill_execution_logger.py
@@ -16,6 +16,7 @@ import json
 import os
 import re
 import sys
+import time
 import traceback
 from collections import defaultdict
 from datetime import datetime, timezone
@@ -64,14 +65,15 @@ class ContinualEvaluator:
             json.dump(dict(self.skill_history), f, indent=None, separators=(",", ":"))
 
     def evaluate_iteration(
-        self, skill_ref: str, success: bool, duration_ms: int
+        self, skill_ref: str, success: bool, duration_ms: int | None
     ) -> dict[str, Any]:
         """Evaluate single iteration using continual metrics.
 
         Args:
             skill_ref: Skill reference (e.g., "abstract:skill-auditor")
             success: Whether execution succeeded
-            duration_ms: Execution duration in milliseconds
+            duration_ms: Execution duration in milliseconds, or None when the
+                execution could not be timed
 
         Returns:
             Dictionary with continual evaluation metrics
@@ -79,7 +81,11 @@ class ContinualEvaluator:
         """
         history = self.skill_history[skill_ref]
         history["accuracies"].append(1 if success else 0)
-        history["durations"].append(duration_ms)
+        # An untimed execution still counts as an execution, so it lands in
+        # accuracies but not in durations. Appending a placeholder would put a
+        # number that was never measured into the average (#671).
+        if duration_ms is not None:
+            history["durations"].append(duration_ms)
 
         # Save history after each iteration
         self._save_history()
@@ -93,7 +99,7 @@ class ContinualEvaluator:
         stability_gap = avg_accuracy - worst_case  # Key innovation!
 
         # Additional metrics
-        avg_duration = sum(durations) / len(durations)
+        avg_duration = sum(durations) / len(durations) if durations else 0.0
         execution_count = len(accuracies)
 
         return {
@@ -179,6 +185,47 @@ def sanitize_output(output: str, max_length: int = 5000) -> str:
     return output
 
 
+# A pre-execution state older than this belongs to an invocation whose post
+# hook never ran. The bound is deliberately generous: a long agent-backed skill
+# can legitimately run for many minutes, and purging a live invocation's state
+# would turn a good measurement into a missing one.
+ORPHAN_STATE_MAX_AGE_S = 3600
+
+
+def _purge_orphan_states(state_files: list[Path]) -> list[Path]:
+    """Delete abandoned pre-execution states, returning the live ones.
+
+    A state file is written by the pre hook and removed by the post hook. One
+    that outlives any plausible execution means the post hook never ran, so it
+    will sit in the directory forever, making every later completion of that
+    skill look ambiguous.
+
+    Args:
+        state_files: Candidate state files for one skill ref.
+
+    Returns:
+        The subset young enough to belong to a live invocation.
+
+    """
+    now = time.time()
+    live: list[Path] = []
+    for path in state_files:
+        try:
+            age = now - path.stat().st_mtime
+        except OSError:
+            continue
+        if age <= ORPHAN_STATE_MAX_AGE_S:
+            live.append(path)
+            continue
+        try:
+            path.unlink()
+        except OSError as exc:
+            sys.stderr.write(
+                f"skill_execution_logger: orphan cleanup failed for {path}: {exc}\n"
+            )
+    return live
+
+
 def create_log_entry(
     tool_input: dict[str, Any],
     tool_output: str,
@@ -207,13 +254,21 @@ def create_log_entry(
     skill_ref = f"{plugin}:{skill}"
     end_time = datetime.now(timezone.utc)
 
-    # Calculate duration from pre-execution state if available
+    # An execution this hook could not time reports None, never 0. A zero is
+    # indistinguishable from a real sub-millisecond reading, so it survives
+    # every downstream ">= 0" filter and counts as a sample, pulling averages
+    # toward zero and hiding the fact that nothing was measured (#671).
+    #
+    # A negative interval is discarded for the same reason. It means the wall
+    # clock moved backward between the two hooks, so no execution took that
+    # long; storing it and leaving the report to filter it out kept a
+    # non-measurement in the record.
+    duration_ms: int | None = None
     if pre_state and "timestamp" in pre_state:
         start_time = datetime.fromisoformat(pre_state["timestamp"])
-        duration_ms = int((end_time - start_time).total_seconds() * 1000)
-    else:
-        # Fallback: approximate with current time
-        duration_ms = 0
+        measured = int((end_time - start_time).total_seconds() * 1000)
+        if measured >= 0:
+            duration_ms = measured
 
     # Determine outcome based on output
     # Check warning first since warnings mentioning "failed" are still partial
@@ -313,13 +368,30 @@ def main() -> None:
         state_dir = get_observability_dir()
         state_files = list(state_dir.glob(f"{skill_ref}:*.json"))
 
-        if state_files:
-            # Get most recent state file
-            latest_file = max(state_files, key=lambda p: p.stat().st_mtime)
-            processing_file = latest_file.with_suffix(".processing")
+        # Orphans first: a state file older than any execution could plausibly
+        # run belongs to an invocation whose post hook never ran, usually a
+        # killed session. Left in place it is indistinguishable from a live
+        # invocation and makes every later completion of this skill ambiguous.
+        state_files = _purge_orphan_states(state_files)
+
+        # The glob keys on skill ref alone, and nothing in a PostToolUse
+        # payload identifies which invocation it belongs to, so with more than
+        # one live candidate this hook cannot know which start time is its
+        # own. Picking either end of the mtime order guesses: newest hands
+        # this entry the start of an invocation still running, which is how a
+        # completion reports an interval that began after it ended, and oldest
+        # is only right when completions happen to be first-in-first-out.
+        #
+        # An unidentifiable pairing is reported as unmeasured rather than
+        # guessed. A wrong interval is worse than a missing one: it is
+        # indistinguishable from a real reading downstream, which is the
+        # conflation #671 exists to remove.
+        if len(state_files) == 1:
+            state_file = state_files[0]
+            processing_file = state_file.with_suffix(".processing")
             try:
                 # Atomic rename to claim the file before reading
-                latest_file.rename(processing_file)
+                state_file.rename(processing_file)
                 with open(processing_file) as f:
                     pre_state = json.load(f)
                 try:

--- a/plugins/abstract/tests/hooks/test_skill_execution_logger.py
+++ b/plugins/abstract/tests/hooks/test_skill_execution_logger.py
@@ -17,6 +17,7 @@ import json
 import os
 import subprocess
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 HOOK = Path(__file__).resolve().parents[2] / "hooks" / "skill_execution_logger.py"
@@ -90,3 +91,147 @@ def test_non_skill_payload_writes_nothing(tmp_path):
     result = _run(payload, tmp_path)
     assert result.returncode == 0, result.stderr
     assert not list((tmp_path / "skills" / "logs").rglob("*.jsonl"))
+
+
+# ---------------------------------------------------------------------------
+# Duration measurement (issue #671)
+#
+# The hook fabricated a duration_ms of 0 whenever it could not find the
+# matching pre-execution state, and nothing downstream could tell that zero
+# from a real sub-millisecond reading. It also paired post to pre by taking
+# the newest state file by mtime, which under overlapping invocations of one
+# skill claims the wrong start time.
+# ---------------------------------------------------------------------------
+
+
+def _write_state(claude_home: Path, skill_ref: str, started_at, mtime_epoch: float):
+    """Write a pre-execution state file with a controlled mtime."""
+    state_dir = claude_home / "skills" / "observability"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    plugin, skill = skill_ref.split(":", 1)
+    invocation_id = f"{skill_ref}:{started_at.timestamp()}"
+    path = state_dir / f"{invocation_id}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "invocation_id": invocation_id,
+                "timestamp": started_at.isoformat(),
+                "skill": skill_ref,
+                "plugin": plugin,
+                "skill_name": skill,
+                "tool_input": {"skill": skill_ref},
+            }
+        )
+    )
+    os.utime(path, (mtime_epoch, mtime_epoch))
+    return invocation_id
+
+
+def _payload(skill_ref: str) -> dict:
+    return {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Skill",
+        "tool_input": {"skill": skill_ref},
+        "tool_response": {"success": True},
+        "session_id": "11111111-2222-3333-4444-555555555555",
+    }
+
+
+def test_unmeasured_execution_reports_none_not_zero(tmp_path):
+    """With no pre-state, duration_ms is None rather than a fabricated 0.
+
+    A zero is indistinguishable from a real sub-millisecond measurement, so
+    it passes every downstream ">= 0" filter and counts as a sample. None
+    says "not measured", which is the truth the entry has to carry.
+    """
+    result = _run(_payload("abstract:skill-auditor"), tmp_path)
+    assert result.returncode == 0, result.stderr
+
+    entries = _entries(tmp_path, "abstract", "skill-auditor")
+    assert entries, f"no telemetry written; stderr={result.stderr}"
+    assert entries[-1]["duration_ms"] is None, (
+        f"unmeasured execution reported {entries[-1]['duration_ms']!r}"
+    )
+
+
+def test_ambiguous_pairing_is_unmeasured_not_guessed(tmp_path):
+    """Two live states for one skill: report None rather than pick one.
+
+    The state glob keys on skill ref alone and a PostToolUse payload carries
+    nothing identifying its invocation, so with two live candidates the hook
+    cannot know which start time is its own. Newest-by-mtime yields the start
+    of an invocation still running (the source of negative intervals);
+    oldest-by-mtime is right only when completions are first-in-first-out.
+    Guessing produces a number indistinguishable from a real measurement,
+    which is the conflation this issue removes.
+    """
+    now = datetime.now(timezone.utc)
+    skill_ref = "abstract:skill-auditor"
+    for offset in (5, 0.5):
+        started = now - timedelta(seconds=offset)
+        _write_state(tmp_path, skill_ref, started, started.timestamp())
+
+    result = _run(_payload(skill_ref), tmp_path)
+    assert result.returncode == 0, result.stderr
+
+    entries = _entries(tmp_path, "abstract", "skill-auditor")
+    assert entries, f"no telemetry written; stderr={result.stderr}"
+    assert entries[-1]["duration_ms"] is None, (
+        f"guessed a pairing among two live states: {entries[-1]['duration_ms']!r}"
+    )
+
+
+def test_orphaned_state_is_purged_so_a_live_pairing_still_resolves(tmp_path):
+    """An abandoned state must not make every later completion ambiguous.
+
+    The pre hook writes a state the post hook removes. When a session dies
+    between them the file survives forever. Treating it as a live candidate
+    would make this skill permanently unmeasurable, so it is purged on sight
+    and the real invocation still gets its interval.
+    """
+    now = datetime.now(timezone.utc)
+    skill_ref = "abstract:skill-auditor"
+    # Abandoned two hours ago: no execution runs that long here.
+    stale = now - timedelta(hours=2)
+    _write_state(tmp_path, skill_ref, stale, stale.timestamp())
+    # The invocation actually finishing now.
+    live = now - timedelta(seconds=3)
+    _write_state(tmp_path, skill_ref, live, live.timestamp())
+
+    result = _run(_payload(skill_ref), tmp_path)
+    assert result.returncode == 0, result.stderr
+
+    entries = _entries(tmp_path, "abstract", "skill-auditor")
+    assert entries, f"no telemetry written; stderr={result.stderr}"
+    duration = entries[-1]["duration_ms"]
+    assert duration is not None, "orphan blocked a resolvable pairing"
+    assert 2000 <= duration <= 10000, (
+        f"paired against the orphan instead of the live state: {duration}ms"
+    )
+
+    state_dir = tmp_path / "skills" / "observability"
+    assert not list(state_dir.glob(f"{skill_ref}:*.json")), (
+        "orphan survived the purge and will re-ambiguate the next completion"
+    )
+
+
+def test_future_dated_pre_state_is_unmeasured_not_negative(tmp_path):
+    """A start time after the end time yields None, never a negative.
+
+    A backward wall-clock adjustment between the two hooks stores an
+    interval no execution could have taken. Reporting it as a measurement
+    is worse than reporting nothing: the -2375ms sample on
+    attune:mission-orchestrator reached the aggregate report this way.
+    """
+    now = datetime.now(timezone.utc)
+    skill_ref = "abstract:skill-auditor"
+    _write_state(tmp_path, skill_ref, now + timedelta(seconds=3), now.timestamp())
+
+    result = _run(_payload(skill_ref), tmp_path)
+    assert result.returncode == 0, result.stderr
+
+    entries = _entries(tmp_path, "abstract", "skill-auditor")
+    assert entries, f"no telemetry written; stderr={result.stderr}"
+    assert entries[-1]["duration_ms"] is None, (
+        f"stored an impossible interval: {entries[-1]['duration_ms']!r}"
+    )

--- a/plugins/abstract/tests/test_hooks_skill_execution_logger.py
+++ b/plugins/abstract/tests/test_hooks_skill_execution_logger.py
@@ -285,7 +285,12 @@ class TestDurationTracking:
 
         Given: No pre-execution state file exists
         When: The PostToolUse hook executes
-        Then: Duration should default to 0 and execution should continue
+        Then: Duration is None and execution should continue
+
+        This asserted a duration of 0 until #671. A zero is indistinguishable
+        from a real sub-millisecond reading, so it passed every downstream
+        ">= 0" filter and was counted as a timing sample that no clock ever
+        produced. None is the honest value for an execution nothing timed.
         """
         # Given
         skill_ref = "abstract:skill-auditor"
@@ -306,7 +311,10 @@ class TestDurationTracking:
         log_file = log_dir / f"{log_date}.jsonl"
         entry = json.loads(log_file.read_text().strip())
 
-        assert entry["duration_ms"] == 0, "Duration should be 0 without pre-state"
+        assert entry["duration_ms"] is None, (
+            f"unmeasured execution reported {entry['duration_ms']!r}, "
+            "which is indistinguishable from a real measurement"
+        )
 
 
 class TestOutcomeDetection:


### PR DESCRIPTION
## Summary

Refs #671.

`skill_execution_logger` produced two numbers that no clock ever
measured, and nothing downstream could tell them from real readings.

## What the logs actually showed

The issue asked for a count before a patch, so that came first. One
pass over 492 entries in 166 files:

| Measure | Result |
|---|---|
| Unpaired entries (bare `uuid4`) | 8 (1.6%) |
| `duration_ms == 0` | 8, **all** unpaired; no paired entry ever produced a 0 |
| Affected skills | 1 of 39, all in `abstract:skill-auditor` |
| Distortion there | 116.8 ms reported vs 119.8 ms true (2.5% understated) |
| Overlapping same-skill invocations | **0** |

The fabricated zero is real but small. The pairing defect had not yet
fired: no two invocations of one skill overlapped, and the tightest
margin was 31 ms.

## Changes

**`duration_ms` is `None` when unmeasured, not `0`.** A zero passes
every `>= 0` filter and counts as a sample. The read side already
excludes `None`.

**A negative interval is discarded at the producer.** It means the wall
clock moved backward between the hooks. The `-2375` sample on
`attune:mission-orchestrator` reached the report this way; it is not a
mispair, as only one invocation of that skill ran within 240 s.

**Pairing no longer guesses.** The state glob keys on skill ref alone
and a PostToolUse payload carries nothing identifying its invocation.
Newest-by-mtime yields the start of an invocation still running; oldest
is right only under first-in-first-out. With two live candidates the
hook now reports unmeasured, because a wrong interval is worse than a
missing one.

**Orphaned states are purged.** Otherwise one abandoned file makes every
later completion of its skill permanently ambiguous.

**`evaluate_iteration` no longer averages a `None`.** An untimed
execution still counts in accuracies, but not in durations.

## Test plan

Five regression tests, each verified red before the fix:

- unmeasured execution reports `None`, not `0`
- ambiguous pairing reports `None` rather than picking
- orphaned state is purged so a live pairing still resolves
- future-dated pre-state yields `None`, never a negative (reproduced
  `-2932`, same class as the production `-2375`)
- the older test pinning `duration_ms == 0` now pins the new contract

Reverting the pairing change to newest-by-mtime turns the two new
pairing tests red.

- [x] `plugins/abstract`: 2343 passed, 3 xfailed
- [x] root `tests/`: 4700 passed
- [x] `ruff check .` and `ruff format --check`: clean
- [x] strict mypy on `abstract`: clean

## Note on the base

Based on `fix/minimax-cli-contract` rather than `master`. That branch
carries the ruff config inheritance fix; on `master` the abstract
plugin config replaces the root floor instead of extending it and
reports 30 pre-existing violations. Retarget to `master` after #662
merges.

## Not done

The 8 existing entries are correctable in place, since the two
`invocation_id` shapes distinguish them. Left alone: that rewrites
historical telemetry outside the repo.