### PR TITLE
Hook fan-out and session-start injection: fix the gate that never ran, then use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `minimax-delegation` skill documents the global and China regional
   OpenAI- and Anthropic-compatible endpoints, model capabilities, and
   token pricing, and the Makefile exposes `make delegate-minimax`.
+
+### Fixed
+
+- **Hook `if` gates were on the wrong object and never ran.** Measured
+  on Claude Code 2.1.245: the harness reads `if` from the hook entry,
+  and the same key on the enclosing matcher group is dropped without an
+  error. Every `if` this repo shipped sat on the group, so gauntlet's
+  precommit gate, pensive's blast-radius hook and cartograph's graph
+  refresh spawned on every Bash call while their configs read as gated.
+  The keys moved into their entries, imbue's three `PreToolUse:Bash`
+  hooks gained gates now that the mechanism works, and
+  `scripts/check_hook_modernization.py` rejects both silent failure
+  modes: a misplaced key that never gates, and an array-valued `if`
+  that suppresses the hook outright with a matching rule present.
+- **A plugin with no coverage threshold reported failure having run
+  nothing.** bash 3.2, which macOS ships, treats an empty array as
+  unset, so `"${cov_flag[@]}"` under `set -u` aborted
+  `scripts/run-plugin-tests.sh` before pytest was invoked. bash 4+
+  expands the same line to nothing, so CI never reproduced it.
+- **The conserve context-estimate cache followed symlinks.** Its path
+  is derived from the transcript path and so is predictable; it now
+  opens with `O_NOFOLLOW` and refuses a file this user does not own
+  (CWE-59), matching the defense imbue keeps in
+  `hooks/shared/vow_utils.py`.
+
+### Changed
+
+- **Session start no longer injects three reference manuals.** Eight
+  plugins register `SessionStart`; three printed documentation totaling
+  9,973 of the 10,770 characters measured across the set, so every
+  session paid for guidance about work most sessions never did. The
+  payloads are now pointers into the skills that already held the
+  detail, down to 2,743 characters, and conserve stopped restating
+  imbue's scope-guard reference that every session paid for twice. A
+  per-payload budget test holds the line.
+- **The context monitor stopped re-reading the transcript per tool
+  call.** `conserve/context_warning.py` parsed up to 4MB of session
+  JSONL on every Write, Edit, Bash, Skill and Task. The alert bands are
+  40%, 50% and 80%, which no session crosses inside half a minute, so
+  the estimate is cached for 30 seconds.
+- **A prompt with no URL stopped paying for the memory-palace shared
+  package.** `url_detector.py` imported `shared.config` and
+  `shared.deduplication` at module scope, 100ms measured with
+  `-X importtime`, for names unreachable until a URL is found.
+  Deferring them takes the quiet path from 90ms to 40ms.
+
 ## [1.9.18] - 2026-08-12
 
 ### Added

--- a/book/src/reference/capabilities-reference.md
+++ b/book/src/reference/capabilities-reference.md
@@ -118,6 +118,7 @@ See [Capabilities Reference Details](capabilities-reference-details.md).
 | `memory-palace-architect` | [memory-palace](../plugins/memory-palace.md) | Building virtual palaces |
 | `metacognitive-self-mod` | [abstract](../plugins/abstract.md) | Hyperagents self-improvement analysis |
 | `methodology-curator` | [abstract](../plugins/abstract.md) | Surface expert frameworks for skill development |
+| `minimax-delegation` | [conjure](../plugins/conjure.md) | MiniMax CLI integration |
 | `mission-orchestrator` | [attune](../plugins/attune.md) | Unified lifecycle orchestrator for project development |
 | `modular-skills` | [abstract](../plugins/abstract.md) | Modular design patterns |
 | `onboard` | [gauntlet](../plugins/gauntlet.md) | Guided five-stage onboarding path through a codebase |

--- a/plugins/cartograph/hooks/hooks.json
+++ b/plugins/cartograph/hooks/hooks.json
@@ -3,12 +3,12 @@
     "PostToolUse": [
       {
         "matcher": "Bash",
-        "if": "Bash(*graph_build*)",
         "hooks": [
           {
             "type": "command",
             "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/graph_community_refresh.py",
-            "timeout": 10
+            "timeout": 10,
+            "if": "Bash(*graph_build*)"
           }
         ]
       }

--- a/plugins/conjure/.claude-plugin/plugin.json
+++ b/plugins/conjure/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "skills": [
     "./skills/delegation-core",
     "./skills/gemini-delegation",
+    "./skills/minimax-delegation",
     "./skills/qwen-delegation",
     "./skills/agent-teams"
   ],
@@ -24,5 +25,7 @@
     "url": "https://github.com/athola"
   },
   "license": "MIT",
-  "dependencies": ["leyline"]
+  "dependencies": [
+    "leyline"
+  ]
 }

--- a/plugins/conjure/skills/minimax-delegation/SKILL.md
+++ b/plugins/conjure/skills/minimax-delegation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: minimax-delegation
-description: Delegates tasks to the MiniMax CLI via delegation-core for MiniMax-M3 and MiniMax-M2.7. Use when delegation-core selects MiniMax or large-context batch processing is needed.
+description: Delegates tasks to MiniMax CLI via delegation-core for MiniMax-M3 and M2.7. Use when delegation-core selects MiniMax or large-context batching is needed.
 alwaysApply: false
 category: delegation-implementation
 tags:

--- a/plugins/conserve/hooks/context_warning.py
+++ b/plugins/conserve/hooks/context_warning.py
@@ -246,10 +246,33 @@ def _cache_path(session_file: Path) -> Path:
     return root / f"context-estimate-{key}.json"
 
 
+# The cache path is derived from the transcript path, so anyone who can
+# read the projects directory can predict it. O_NOFOLLOW makes open()
+# fail with ELOOP when the final component is a symlink, so a planted
+# link cannot redirect this hook's truncating write onto its target, nor
+# feed it a chosen number (CWE-59). imbue keeps the same defense in
+# hooks/shared/vow_utils.py; a plugin cannot import another's hooks, so
+# this is a deliberate second copy rather than a shared one.
+_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+
+
+def _open_cache(path: Path, flags: int) -> int:
+    """Open *path* refusing symlinks, and refuse a file we do not own."""
+    fd = os.open(str(path), flags | _O_NOFOLLOW, 0o600)
+    geteuid = getattr(os, "geteuid", None)
+    if geteuid is not None and os.fstat(fd).st_uid != geteuid():
+        os.close(fd)
+        msg = f"{path} is not owned by this user"
+        raise OSError(msg)
+    return fd
+
+
 def _read_cached_estimate(session_file: Path) -> float | None:
     """Return the cached estimate, or None if absent, stale or unreadable."""
     try:
-        payload = json.loads(_cache_path(session_file).read_text())
+        fd = _open_cache(_cache_path(session_file), os.O_RDONLY)
+        with os.fdopen(fd, encoding="utf-8") as fh:
+            payload = json.loads(fh.read())
         if time.time() - payload["at"] > _CACHE_TTL_SECONDS:
             return None
         usage = payload["usage"]
@@ -260,10 +283,11 @@ def _read_cached_estimate(session_file: Path) -> float | None:
 
 def _write_cached_estimate(session_file: Path, usage: float) -> None:
     """Record *usage* for the next call inside the window."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
     try:
-        _cache_path(session_file).write_text(
-            json.dumps({"at": time.time(), "usage": usage})
-        )
+        fd = _open_cache(_cache_path(session_file), flags)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps({"at": time.time(), "usage": usage}))
     except OSError as e:
         # A cache we cannot write makes the hook slower, not wrong.
         logger.debug("Could not write context estimate cache: %s", e)

--- a/plugins/conserve/hooks/context_warning.py
+++ b/plugins/conserve/hooks/context_warning.py
@@ -19,10 +19,12 @@ Environment variables:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
 import sys
+import tempfile
 import time
 from dataclasses import dataclass
 from enum import Enum
@@ -217,6 +219,56 @@ def _resolve_session_file() -> Path | None:
     return _find_current_session(jsonl_files)
 
 
+# The transcript estimate is reused for this long. The alert bands are
+# 40%, 50% and 80% of the window, and context does not cross one inside
+# half a minute, so per-call resolution buys nothing and costs a 4MB
+# read on every Write, Edit, Bash, Skill and Task.
+_CACHE_TTL_SECONDS = 30
+
+
+def _cache_path(session_file: Path) -> Path:
+    """Return the file holding the last estimate for *session_file*.
+
+    Keyed by the transcript path, which is the one input the cached
+    number is derived from: a second session, in this checkout or
+    another, resolves to a different transcript and gets its own entry.
+    ``CONSERVE_STATE_DIR`` overrides the base directory.
+    """
+    override = os.environ.get("CONSERVE_STATE_DIR")
+    if override:
+        root = Path(override)
+    else:
+        uid = getattr(os, "geteuid", lambda: 0)()
+        root = Path(tempfile.gettempdir()) / f"conserve-{uid}"
+    root.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+    key = hashlib.sha256(str(session_file).encode()).hexdigest()[:16]
+    return root / f"context-estimate-{key}.json"
+
+
+def _read_cached_estimate(session_file: Path) -> float | None:
+    """Return the cached estimate, or None if absent, stale or unreadable."""
+    try:
+        payload = json.loads(_cache_path(session_file).read_text())
+        if time.time() - payload["at"] > _CACHE_TTL_SECONDS:
+            return None
+        usage = payload["usage"]
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+    return usage if isinstance(usage, float) else None
+
+
+def _write_cached_estimate(session_file: Path, usage: float) -> None:
+    """Record *usage* for the next call inside the window."""
+    try:
+        _cache_path(session_file).write_text(
+            json.dumps({"at": time.time(), "usage": usage})
+        )
+    except OSError as e:
+        # A cache we cannot write makes the hook slower, not wrong.
+        logger.debug("Could not write context estimate cache: %s", e)
+
+
 def estimate_context_from_session() -> float | None:
     """Estimate context usage from current session's JSONL conversation data.
 
@@ -243,7 +295,13 @@ def estimate_context_from_session() -> float | None:
         if current_session is None:
             return None
 
+        cached = _read_cached_estimate(current_session)
+        if cached is not None:
+            return cached
+
         usage = _estimate_from_recent_turns(current_session)
+        if usage is not None:
+            _write_cached_estimate(current_session, usage)
         logger.debug(
             "Estimated context from %s: %.1f%%",
             current_session.name,

--- a/plugins/conserve/hooks/session-start.sh
+++ b/plugins/conserve/hooks/session-start.sh
@@ -101,92 +101,24 @@ EOF
 esac
 
 # Build conservation skills summary for session context injection
-conservation_summary='## Conservation Skills - Session Optimization
+conservation_summary='## conserve: session optimization
 
-**Active at session start to optimize performance, tokens, and context.**
+Context bands, and what each asks for: under 40% carry on; 40-50% plan the
+optimization; 50-80% act on it, summarizing or delegating; at 80% invoke
+`Skill(conserve:clear-context)`, which checkpoints state and hands off to a
+continuation agent. `CLAUDE_CONTEXT_USAGE` is often unset, so run `/context`
+at natural breakpoints rather than waiting to be told a number.
 
-### Quick Reference
+Skills: `Skill(conserve:context-optimization)` for MECW assessment,
+`Skill(conserve:token-conservation)` for quota planning,
+`Skill(conserve:cpu-gpu-performance)` before builds, tests and training runs.
 
-| Skill | Purpose | When to Use |
-|-------|---------|-------------|
-| `context-optimization` | MECW principles, 50% context rule | Context > 30% utilization |
-| `clear-context` | **Auto-clear workflow** | Context > 80% OR long multi-step tasks |
-| `token-conservation` | Token usage strategies, quota tracking | Start of session, before heavy loads |
-| `cpu-gpu-performance` | Resource monitoring, selective testing | Before builds/tests/training |
+A 1M window retires none of this, it changes the arithmetic. 1M of stale
+tool output reasons worse than 200K of relevant state, and every turn pays
+for the whole window against quota. Plan, `/clear`, then implement.
 
-### Key Thresholds (Three-Tier MECW Alerts)
-
-| Level | Threshold | Action |
-|-------|-----------|--------|
-| OK | < 40% | Continue normally |
-| WARNING | 40-50% | Plan optimization, monitor growth |
-| CRITICAL | 50-80% | Immediate optimization, summarize/delegate |
-| **EMERGENCY** | **80%+** | **Invoke `Skill(conserve:clear-context)` NOW** |
-
-### Proactive Self-Monitoring (IMPORTANT)
-
-During **long-running or multi-step tasks** (brainstorms, execute-plan, large refactors):
-
-1. **Check context periodically**: Run `/context` at natural breakpoints
-2. **At 80%+ usage**: Immediately invoke `Skill(conserve:clear-context)`
-3. **The skill will**: Save session state, spawn continuation agent, resume seamlessly
-
-**Why self-monitor?** The `CLAUDE_CONTEXT_USAGE` env var may not be set.
-Proactive checking prevents auto-compact penalties.
-
-### 1M Context Strategy
-
-The 1M window (GA for Opus/Sonnet 4.6) does not replace
-conservation; it changes what conservation means.
-A 1M window full of stale tool outputs performs worse
-than 200K of relevant, well-organized state.
-
-**Plan-Clear-Implement pattern** (recommended workflow):
-1. Build the full plan (spec-kit, built-in planning, etc.)
-2. `/clear` or `/compact` to start clean
-3. Implement without compaction: maintain full context
-4. Iterate while still on topic with the same context
-5. Repeat for the next plan
-
-**Quota awareness**: Larger context = more input tokens
-per turn = faster quota burn. Surgical reads protect
-your budget even when the window allows more.
-
-**Agentic isolation**: Parallel agents compound bloat.
-Use git worktrees (`isolation: "worktree"`) to keep each
-agent context lean and prevent cross-contamination.
-
-### Conservation Tactics
-
-1. **Prefer targeted over broad**: `rg`/`sed -n` slices vs whole files
-2. **Delegate compute**: Use external tooling for intensive tasks
-3. **Compress context**: Summarize prior steps, remove redundant history
-4. **Scope narrow**: Diff-based testing vs full suite
-5. **Checkpoint long tasks**: Save state at natural breakpoints
-
-### Skill Invocation
-
-- `Skill(conserve:clear-context)` - **Auto-clear with continuation agent**
-- `Skill(conserve:context-optimization)` - MECW assessment and optimization
-- `Skill(conserve:token-conservation)` - Token budget planning
-- `Skill(conserve:cpu-gpu-performance)` - Resource monitoring discipline
-
-### Bypass Modes
-
-Set `CONSERVATION_MODE` environment variable:
-- `quick` - Skip guidance for fast processing
-- `deep` - Allow extended resources for thorough analysis
-- `normal` - Default, full conservation guidance
-
-### Scope-Guard Principles (from imbue)
-
-- **Worthiness**: `(BizValue + TimeCrit + RiskReduce) / (Complexity + TokenCost + ScopeDrift)`: >2.0 implement, 1-2 discuss, <1 defer
-- **Anti-overengineering**: Ask before proposing; no abstraction until 3rd use; defer nice-to-haves; stay within branch budget
-- **Branch thresholds**: 1000/1500/2000 lines | 15/25/30 commits | 3/7/7+ days (green/yellow/red)
-- **Proof-of-work**: Never claim "should work"; run it, test it, cite evidence `[E1]`/`[E2]`
-- **Iron Law**: No implementation without a failing test first
-- **Rigorous reasoning**: No courtesy agreement; follow analysis checklists, not gut reactions
-- Invoke `Skill(imbue:scope-guard)`, `Skill(imbue:proof-of-work)`, or `Skill(imbue:rigorous-reasoning)` for full methodology'
+`CONSERVATION_MODE` selects the register: `quick` skips this guidance,
+`deep` allows extended resources, `normal` is the default.'
 
 # Add deep mode notice if applicable
 if [ -n "$deep_mode_msg" ]; then

--- a/plugins/conserve/tests/unit/test_context_warning_cache.py
+++ b/plugins/conserve/tests/unit/test_context_warning_cache.py
@@ -1,0 +1,148 @@
+"""The JSONL estimate is cached, so the hot path re-reads nothing.
+
+`context_warning.py` runs on PreToolUse for Write, Edit, Bash, Skill and
+Task. Without `CLAUDE_CONTEXT_USAGE` set it falls back to reading up to
+4MB off the tail of the session transcript and JSON-parsing every line,
+and it did that once per tool call. Telemetry over 4,028 Bash calls put
+the PreToolUse chain at a 26s worst case; a 4MB parse on a cold page
+cache is a candidate for that shape of outlier.
+
+Context does not move fast enough to need per-call resolution -- the
+alert bands are 40%, 50% and 80% -- so the estimate is cached for
+`_CACHE_TTL_SECONDS` and reused. These tests pin the cache: reused
+inside the window, recomputed after it, and never shared between
+sessions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(monkeypatch, tmp_path):
+    """Point the hook at a private state dir and an empty environment."""
+    monkeypatch.setenv("CONSERVE_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.delenv("CLAUDE_CONTEXT_USAGE", raising=False)
+    monkeypatch.delenv("CONSERVE_CONTEXT_ESTIMATION", raising=False)
+    monkeypatch.delenv("CLAUDE_HOME", raising=False)
+
+
+def _fake_session(monkeypatch, tmp_path, session_id: str = "session-a"):
+    """Create a session transcript the estimator will resolve to."""
+    home = tmp_path / "home"
+    cwd = tmp_path / "work"
+    cwd.mkdir(parents=True, exist_ok=True)
+    project_dir = home / ".claude" / "projects" / str(cwd).replace("/", "-")
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / f"{session_id}.jsonl").write_text("x" * 80000)
+    monkeypatch.setenv("CLAUDE_SESSION_ID", session_id)
+    monkeypatch.setattr("pathlib.Path.cwd", staticmethod(lambda: cwd))
+    monkeypatch.setattr("pathlib.Path.home", staticmethod(lambda: home))
+    return project_dir
+
+
+class _EstimatorSpy:
+    """Stand in for _estimate_from_recent_turns and count the reads."""
+
+    def __init__(self, value: float = 0.42) -> None:
+        self.value = value
+        self.calls = 0
+
+    def __call__(self, session_file) -> float:
+        self.calls += 1
+        return self.value
+
+
+class TestEstimateIsCachedWithinTheWindow:
+    """Feature: repeated tool calls reuse one transcript read."""
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_second_call_does_not_reread_the_transcript(
+        self, context_warning_full_module, monkeypatch, tmp_path
+    ) -> None:
+        """Scenario: two tool calls in a row share one transcript read."""
+        module = context_warning_full_module
+        _fake_session(monkeypatch, tmp_path)
+        spy = _EstimatorSpy()
+        monkeypatch.setattr(module, "_estimate_from_recent_turns", spy)
+
+        first = module.estimate_context_from_session()
+        second = module.estimate_context_from_session()
+
+        assert first == second == spy.value
+        assert spy.calls == 1
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_estimate_is_recomputed_once_the_window_expires(
+        self, context_warning_full_module, monkeypatch, tmp_path
+    ) -> None:
+        """Scenario: the estimate goes stale and is taken again."""
+        module = context_warning_full_module
+        _fake_session(monkeypatch, tmp_path)
+        spy = _EstimatorSpy()
+        monkeypatch.setattr(module, "_estimate_from_recent_turns", spy)
+
+        clock = [1000.0]
+        monkeypatch.setattr(module.time, "time", lambda: clock[0])
+
+        module.estimate_context_from_session()
+        clock[0] += module._CACHE_TTL_SECONDS + 1
+        module.estimate_context_from_session()
+
+        assert spy.calls == 2
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_a_different_session_does_not_read_the_first_cache(
+        self, context_warning_full_module, monkeypatch, tmp_path
+    ) -> None:
+        """Scenario: each transcript gets its own cache entry."""
+        module = context_warning_full_module
+        _fake_session(monkeypatch, tmp_path, session_id="session-a")
+        spy = _EstimatorSpy()
+        monkeypatch.setattr(module, "_estimate_from_recent_turns", spy)
+        module.estimate_context_from_session()
+
+        _fake_session(monkeypatch, tmp_path, session_id="session-b")
+        module.estimate_context_from_session()
+
+        assert spy.calls == 2
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_env_var_path_never_touches_the_cache(
+        self, context_warning_full_module, monkeypatch, tmp_path
+    ) -> None:
+        """Scenario: CLAUDE_CONTEXT_USAGE short-circuits before any file work."""
+        module = context_warning_full_module
+        _fake_session(monkeypatch, tmp_path)
+        spy = _EstimatorSpy()
+        monkeypatch.setattr(module, "_estimate_from_recent_turns", spy)
+        monkeypatch.setenv("CLAUDE_CONTEXT_USAGE", "0.31")
+
+        usage, is_estimated = module.get_context_usage_from_env()
+
+        assert usage == 0.31
+        assert is_estimated is False
+        assert spy.calls == 0
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_an_unreadable_cache_falls_back_to_estimating(
+        self, context_warning_full_module, monkeypatch, tmp_path
+    ) -> None:
+        """A corrupt cache must not take the hook's answer with it."""
+        module = context_warning_full_module
+        _fake_session(monkeypatch, tmp_path)
+        spy = _EstimatorSpy()
+        monkeypatch.setattr(module, "_estimate_from_recent_turns", spy)
+
+        module.estimate_context_from_session()
+        cached = next((tmp_path / "state").glob("context-estimate-*.json"))
+        cached.write_text("{not json")
+
+        assert module.estimate_context_from_session() == spy.value
+        assert spy.calls == 2

--- a/plugins/conserve/tests/unit/test_context_warning_cache.py
+++ b/plugins/conserve/tests/unit/test_context_warning_cache.py
@@ -146,3 +146,58 @@ class TestEstimateIsCachedWithinTheWindow:
 
         assert module.estimate_context_from_session() == spy.value
         assert spy.calls == 2
+
+
+class TestCachePathIsNotFollowedThroughASymlink:
+    """Feature: a planted symlink cannot redirect the cache write.
+
+    The cache path is derived from the transcript path, so it is
+    predictable to anyone who can read the projects directory. A
+    truncating write onto a symlink at that path lands on the target
+    instead (CWE-59). imbue keeps the same defense in
+    `hooks/shared/vow_utils.py` for its state files; conserve cannot
+    import across plugins, so it carries its own copy.
+    """
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_write_refuses_a_symlinked_cache_path(
+        self, context_warning_full_module, monkeypatch, tmp_path
+    ) -> None:
+        """Scenario: the victim file is left untouched."""
+        module = context_warning_full_module
+        _fake_session(monkeypatch, tmp_path)
+        spy = _EstimatorSpy()
+        monkeypatch.setattr(module, "_estimate_from_recent_turns", spy)
+
+        victim = tmp_path / "victim.txt"
+        victim.write_text("do not clobber me")
+        state = tmp_path / "state"
+        state.mkdir(parents=True, exist_ok=True)
+        session_file = module._resolve_session_file()
+        module._cache_path(session_file).symlink_to(victim)
+
+        usage = module.estimate_context_from_session()
+
+        assert usage == spy.value
+        assert victim.read_text() == "do not clobber me"
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_read_refuses_a_symlinked_cache_path(
+        self, context_warning_full_module, monkeypatch, tmp_path
+    ) -> None:
+        """Scenario: a planted symlink cannot feed the hook a value."""
+        module = context_warning_full_module
+        _fake_session(monkeypatch, tmp_path)
+        spy = _EstimatorSpy()
+        monkeypatch.setattr(module, "_estimate_from_recent_turns", spy)
+
+        planted = tmp_path / "planted.json"
+        planted.write_text('{"at": 9e9, "usage": 0.99}')
+        state = tmp_path / "state"
+        state.mkdir(parents=True, exist_ok=True)
+        session_file = module._resolve_session_file()
+        module._cache_path(session_file).symlink_to(planted)
+
+        assert module.estimate_context_from_session() == spy.value

--- a/plugins/gauntlet/hooks/hooks.json
+++ b/plugins/gauntlet/hooks/hooks.json
@@ -3,12 +3,12 @@
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "if": "Bash(git commit*)",
         "hooks": [
           {
             "type": "command",
             "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/precommit_gate.py",
-            "timeout": 2
+            "timeout": 2,
+            "if": "Bash(git commit*)"
           }
         ]
       }
@@ -16,12 +16,12 @@
     "PostToolUse": [
       {
         "matcher": "Bash",
-        "if": "Bash(git commit*)",
         "hooks": [
           {
             "type": "command",
             "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/graph_auto_update.py",
-            "timeout": 5
+            "timeout": 5,
+            "if": "Bash(git commit*)"
           }
         ]
       }

--- a/plugins/imbue/hooks/hooks.json
+++ b/plugins/imbue/hooks/hooks.json
@@ -28,7 +28,8 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/vow_no_ai_attribution.py",
-            "timeout": 2
+            "timeout": 2,
+            "if": "Bash(git commit*)"
           }
         ]
       },
@@ -38,7 +39,8 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/vow_no_emoji_commits.py",
-            "timeout": 2
+            "timeout": 2,
+            "if": "Bash(git commit*)"
           }
         ]
       },
@@ -48,7 +50,74 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/guard_package_hallucination.py",
-            "timeout": 8
+            "timeout": 8,
+            "if": "Bash(*pip*)"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/guard_package_hallucination.py",
+            "timeout": 8,
+            "if": "Bash(uv add*)"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/guard_package_hallucination.py",
+            "timeout": 8,
+            "if": "Bash(poetry add*)"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/guard_package_hallucination.py",
+            "timeout": 8,
+            "if": "Bash(pdm add*)"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/guard_package_hallucination.py",
+            "timeout": 8,
+            "if": "Bash(*npm *)"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/guard_package_hallucination.py",
+            "timeout": 8,
+            "if": "Bash(yarn add*)"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/guard_package_hallucination.py",
+            "timeout": 8,
+            "if": "Bash(cargo add*)"
           }
         ]
       },

--- a/plugins/imbue/hooks/session-start.sh
+++ b/plugins/imbue/hooks/session-start.sh
@@ -120,92 +120,26 @@ if [ "$in_git_repo" = true ]; then
 fi
 
 # Read scope-guard skill summary (lightweight version for session context)
-scope_guard_summary="## scope-guard Quick Reference
+scope_guard_summary="## imbue quick reference
 
-**When to invoke** \`Skill(imbue:scope-guard)\`:
-- After brainstorming sessions (before documenting designs)
-- Before finalizing implementation plans
-- When proposing new features or abstractions
-- When branch metrics approach thresholds
+Routing only. Each skill body carries its own checklists and thresholds.
 
-**Worthiness Formula**: \`(BizValue + TimeCrit + RiskReduce) / (Complexity + TokenCost + ScopeDrift)\`
-- Score > 2.0: Implement now
-- Score 1.0-2.0: Discuss first
-- Score < 1.0: Defer to backlog
+\`Skill(imbue:scope-guard)\` -- after brainstorming, before finalizing a
+plan, when proposing a feature or an abstraction, or when branch metrics
+approach the limits. Worthiness is
+\`(BizValue + TimeCrit + RiskReduce) / (Complexity + TokenCost + ScopeDrift)\`:
+above 2.0 implement, 1.0 to 2.0 discuss first, below 1.0 defer. Branch
+thresholds are 1000/1500/2000 lines, 15/25/30 commits, 3/7/7+ days.
 
-**Anti-Overengineering Rules**:
-- Ask clarifying questions BEFORE proposing solutions
-- No abstraction until 3rd use case
-- Defer 'nice to have' features to backlog
-- Stay within branch budget (default: 3 major features)
+\`Skill(imbue:proof-of-work)\` -- before claiming an implementation is
+complete, or recommending a solution you have not run. Evidence is command
+output cited as \`[E1]\`, from a functional test rather than a syntax check,
+reported PASS / FAIL / BLOCKED. The Iron Law it enforces: no implementation
+without a failing test first.
 
-**Branch Thresholds**: 1000/1500/2000 lines | 15/25/30 commits | 3/7/7+ days
-
-## proof-of-work Quick Reference
-
-**When to invoke** \`Skill(imbue:proof-of-work)\`:
-- Before claiming ANY implementation is complete
-- Before saying 'should work' or 'will work'
-- Before recommending untested solutions
-- After making code changes that need verification
-
-**Required Evidence**:
-- \`[E1]\`, \`[E2]\` references with command outputs
-- Functional tests (not just syntax checks)
-- Status: PASS / FAIL / BLOCKED
-
-**Red Flags (STOP immediately)**:
-| Thought | Action |
-|---------|--------|
-| 'This looks correct' | RUN IT |
-| 'Should work' | TEST IT |
-| 'Syntax valid' | FUNCTIONAL TEST |
-
-## The Iron Law (TDD Compliance)
-
-\`\`\`
-NO IMPLEMENTATION WITHOUT A FAILING TEST FIRST
-\`\`\`
-
-**Self-Check Before Writing Code**:
-| Question | Wrong Answer | Action |
-|----------|--------------|--------|
-| Evidence of failure/need? | No | STOP - document failure first |
-| Testing pre-conceived impl? | Yes | STOP - let test DRIVE design |
-| Feeling design uncertainty? | No | STOP - uncertainty is GOOD |
-| Did test drive impl? | No | STOP - doing it backwards |
-
-**TDD TodoWrite Items**:
-- \`proof:iron-law-red\` - Failing test written FIRST
-- \`proof:iron-law-green\` - Minimal implementation passes
-- \`proof:iron-law-refactor\` - Improved without behavior change
-
-## rigorous-reasoning Quick Reference
-
-**When to invoke** \`Skill(imbue:rigorous-reasoning)\`:
-- Analyzing conflicts, disagreements, or ethical questions
-- Evaluating contested claims or competing positions
-- When self-monitoring detects sycophantic patterns
-
-**Priority Signals (override defaults)**:
-- No courtesy agreement: Agreement requires validity, not politeness
-- Checklist over intuition: Follow analysis, not initial reactions
-- Uncomfortable conclusions stay uncomfortable: Don't sand down edges
-
-**Red Flags (STOP - you're being sycophantic)**:
-| Thought | Action |
-|---------|--------|
-| 'I agree that...' | VALIDATE first |
-| 'You're right...' | CHECK for evidence |
-| 'Great point!' | Does this ADD value? |
-| 'To be fair...' | Are you HEDGING without evidence? |
-
-**Conflict Analysis Checklist**:
-1. Set aside initial reactions (name the bias)
-2. Complete harm/rights checklist (concrete harm? which right?)
-3. Assess proportionality (was response proportionate?)
-4. Commit to conclusion (follow checklist, not gut)
-5. Guard against retraction (only update for substantive reasons)"
+\`Skill(imbue:rigorous-reasoning)\` -- when analyzing a conflict, a contested
+claim, or competing positions, where the comfortable answer and the correct
+one may differ."
 
 summary_escaped=$(escape_for_json "$scope_guard_summary")
 reminder_escaped=$(escape_for_json "$scope_guard_reminder")

--- a/plugins/imbue/tests/unit/hooks/test_bash_hook_if_gates.py
+++ b/plugins/imbue/tests/unit/hooks/test_bash_hook_if_gates.py
@@ -1,0 +1,182 @@
+"""The `if` gates on imbue's PreToolUse:Bash hooks cover what the hooks inspect.
+
+Three imbue hooks matched every Bash call and then exited early on almost
+all of them. The harness can decide that without spawning a process, via
+the hook-entry `if` field, but only if the registered rules are a superset
+of what each hook's own parser recognizes. A rule that is narrower than
+the parser turns a guard off silently, which for the package guard means a
+typosquat install stops being checked.
+
+These tests pin the superset relation. Adding an ecosystem to
+``_INSTALL_HEADS`` without adding a gate fails here.
+
+Gate semantics measured on Claude Code 2.1.245 (see
+``docs/plans/hook-fanout-and-context-budget.md``): the rule body is an
+fnmatch glob, and a compound command is split so each segment is tested
+on its own.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).resolve().parents[3] / "hooks"
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+from shared.package_guard import (  # noqa: E402 - hooks/ must join sys.path above before its shared/ package resolves
+    _INSTALL_HEADS,
+    parse_packages,
+)
+from shared.vow_utils import (  # noqa: E402 - same sys.path ordering requirement
+    is_git_commit,
+)
+
+_HOOKS_JSON = _HOOKS_DIR / "hooks.json"
+_SEGMENT_SEPARATORS = ("&&", "||", ";", "|")
+
+# One command per entry in _INSTALL_HEADS, in the same order. The count
+# assertion below is what fails when an ecosystem is added upstream.
+_INSTALL_COMMANDS = [
+    "pip install reqeusts",
+    "uv pip install reqeusts",
+    "uv add reqeusts",
+    "poetry add reqeusts",
+    "npm install lodahs",
+    "yarn add lodahs",
+    "cargo add serd",
+]
+
+_EXTRA_INSTALL_COMMANDS = [
+    "pip3 install reqeusts",
+    "python3 -m pip install reqeusts",
+    "pdm add reqeusts",
+    "pnpm add lodahs",
+    "npm i lodahs",
+]
+
+_UNRELATED_COMMANDS = [
+    "ls -la",
+    "cat README.md",
+    "rg install src/",
+    "git status",
+]
+
+
+def _gates_for(script_name: str) -> list[str]:
+    """Return every `if` rule registered against *script_name*."""
+    config = json.loads(_HOOKS_JSON.read_text())
+    rules = []
+    for groups in config["hooks"].values():
+        for group in groups:
+            for entry in group["hooks"]:
+                if script_name in entry.get("command", "") and "if" in entry:
+                    rules.append(entry["if"])
+    return rules
+
+
+def _segments(command: str) -> list[str]:
+    parts = [command]
+    for sep in _SEGMENT_SEPARATORS:
+        parts = [piece for part in parts for piece in part.split(sep)]
+    return [part.strip() for part in parts if part.strip()]
+
+
+def _gate_matches(rule: str, command: str) -> bool:
+    """Mirror the measured harness rule: Bash(<glob>) per command segment."""
+    assert rule.startswith("Bash(") and rule.endswith(")"), rule
+    glob = rule[len("Bash(") : -1]
+    return any(fnmatch.fnmatch(segment, glob) for segment in _segments(command))
+
+
+def _any_gate_matches(script_name: str, command: str) -> bool:
+    return any(_gate_matches(rule, command) for rule in _gates_for(script_name))
+
+
+class TestGatesAreRegisteredAsStrings:
+    """An array-valued `if` suppressed the hook outright when measured."""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "script",
+        [
+            "vow_no_ai_attribution.py",
+            "vow_no_emoji_commits.py",
+            "guard_package_hallucination.py",
+        ],
+    )
+    def test_every_bash_hook_declares_at_least_one_string_gate(self, script):
+        rules = _gates_for(script)
+        assert rules, f"{script} has no `if` gate and spawns on every Bash call"
+        assert all(isinstance(rule, str) for rule in rules)
+
+
+class TestCommitVowGates:
+    """Feature: the commit vows gate on exactly what is_git_commit accepts."""
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "script", ["vow_no_ai_attribution.py", "vow_no_emoji_commits.py"]
+    )
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'git commit -m "feat: thing"',
+            "git commit --amend",
+            'git add . && git commit -m "feat: thing"',
+        ],
+    )
+    def test_gate_admits_commands_the_hook_inspects(self, script, command):
+        assert _any_gate_matches(script, command)
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "script", ["vow_no_ai_attribution.py", "vow_no_emoji_commits.py"]
+    )
+    @pytest.mark.parametrize("command", _UNRELATED_COMMANDS)
+    def test_gate_rejects_commands_the_hook_ignores(self, script, command):
+        assert not is_git_commit(command)
+        assert not _any_gate_matches(script, command)
+
+
+class TestPackageGuardGates:
+    """Feature: every ecosystem the guard parses has a gate admitting it."""
+
+    _SCRIPT = "guard_package_hallucination.py"
+
+    @pytest.mark.unit
+    def test_one_sample_command_per_install_head(self):
+        assert len(_INSTALL_COMMANDS) == len(_INSTALL_HEADS), (
+            "_INSTALL_HEADS changed; add a sample command and a gate for the "
+            "new ecosystem"
+        )
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    @pytest.mark.parametrize("command", _INSTALL_COMMANDS + _EXTRA_INSTALL_COMMANDS)
+    def test_gate_admits_every_install_the_guard_parses(self, command):
+        assert parse_packages(command), f"guard does not parse {command!r}"
+        assert _any_gate_matches(self._SCRIPT, command), (
+            f"{command!r} is inspected by the guard but no `if` gate admits "
+            "it, so the guard would never run for it"
+        )
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    @pytest.mark.parametrize("command", _UNRELATED_COMMANDS)
+    def test_gate_rejects_commands_the_guard_ignores(self, command):
+        assert not parse_packages(command)
+        assert not _any_gate_matches(self._SCRIPT, command)
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_gate_admits_a_compound_install(self):
+        command = "cd /tmp && pip install reqeusts"
+        assert _any_gate_matches(self._SCRIPT, command)

--- a/plugins/imbue/tests/unit/skills/test_proof_of_work.py
+++ b/plugins/imbue/tests/unit/skills/test_proof_of_work.py
@@ -255,9 +255,12 @@ class TestGovernancePolicyIronLaw:
         When reading the hook content
         Then it should include the Iron Law statement.
         """
-        # Assert - Iron Law statement exists
+        # Assert - Iron Law statement exists. The injected payload states
+        # it in prose rather than shouting it; the shouted form lives in
+        # the skill body, which is where the enforcement detail belongs.
         assert "Iron Law" in policy_content
-        assert "NO IMPLEMENTATION WITHOUT A FAILING TEST FIRST" in policy_content
+        collapsed = " ".join(policy_content.lower().split())
+        assert "no implementation without a failing test first" in collapsed
 
     @pytest.mark.bdd
     @pytest.mark.unit
@@ -266,14 +269,28 @@ class TestGovernancePolicyIronLaw:
     ) -> None:
         """Scenario: Governance policy mentions Iron Law TodoWrite items.
 
-        Given the post_implementation_policy hook
-        When reading the hook content
-        Then it should mention iron-law TodoWrite items.
+        Given the proof-of-work skill the governance policy routes to
+        When reading the skill body
+        Then it should define the iron-law TodoWrite items.
+
+        The item names used to be listed in the injected policy too. They
+        are procedure, not routing, so they now live only in the skill
+        that runs the procedure -- but something still has to pin them,
+        which is what this checks.
         """
-        # Assert - TodoWrite items mentioned
-        assert "iron-law-red" in policy_content
-        assert "iron-law-green" in policy_content
-        assert "iron-law-refactor" in policy_content
+        # Assert - the policy routes to the skill that defines them
+        assert "Skill(imbue:proof-of-work)" in policy_content
+
+        skill = (
+            Path(__file__).parents[3]
+            / "skills"
+            / "proof-of-work"
+            / "modules"
+            / "iron-law-enforcement.md"
+        ).read_text()
+        assert "iron-law-red" in skill
+        assert "iron-law-green" in skill
+        assert "iron-law-refactor" in skill
 
 
 class TestSessionStartIronLaw:
@@ -307,7 +324,8 @@ class TestSessionStartIronLaw:
         """
         # Assert - Iron Law section exists
         assert "Iron Law" in session_hook_content
-        assert "NO IMPLEMENTATION WITHOUT A FAILING TEST FIRST" in session_hook_content
+        collapsed = " ".join(session_hook_content.lower().split())
+        assert "no implementation without a failing test first" in collapsed
 
     @pytest.mark.bdd
     @pytest.mark.unit
@@ -318,12 +336,23 @@ class TestSessionStartIronLaw:
 
         Given the imbue session-start.sh hook
         When reading the hook content
-        Then it should mention iron-law TodoWrite items.
+        Then it should route to the skill that defines those items.
+
+        The hook injects into every session, so it carries the pointer
+        and the skill carries the procedure.
         """
-        # Assert - TodoWrite items mentioned
-        assert "iron-law-red" in session_hook_content
-        assert "iron-law-green" in session_hook_content
-        assert "iron-law-refactor" in session_hook_content
+        # Assert - the injection routes to the skill that defines them
+        assert "Skill(imbue:proof-of-work)" in session_hook_content
+
+        skill = (
+            Path(__file__).parents[3]
+            / "skills"
+            / "proof-of-work"
+            / "modules"
+            / "iron-law-enforcement.md"
+        ).read_text()
+        for item in ("iron-law-red", "iron-law-green", "iron-law-refactor"):
+            assert item in skill
 
 
 class TestProofEnforcementIronLaw:

--- a/plugins/imbue/tests/unit/skills/test_rigorous_reasoning.py
+++ b/plugins/imbue/tests/unit/skills/test_rigorous_reasoning.py
@@ -442,12 +442,22 @@ class TestSessionStartHookIntegration:
 
         Given the imbue session-start.sh hook
         When reading the hook content
-        Then it should mention sycophantic patterns to avoid.
+        Then it should route to the skill that lists those patterns.
+
+        The list itself was a rationalization table, which
+        `.claude/rules/bounded-autonomy.md` retires by name. It lives in
+        the skill body, and this pins it there.
         """
-        assert (
-            "I agree that" in session_hook_content
-            or "sycophantic" in session_hook_content.lower()
-        )
+        assert "Skill(imbue:rigorous-reasoning)" in session_hook_content
+
+        skill = (
+            Path(__file__).parents[3]
+            / "skills"
+            / "rigorous-reasoning"
+            / "modules"
+            / "priority-signals.md"
+        ).read_text()
+        assert "courtesy agreement" in skill.lower()
 
     @pytest.mark.bdd
     @pytest.mark.unit

--- a/plugins/memory-palace/hooks/url_detector.py
+++ b/plugins/memory-palace/hooks/url_detector.py
@@ -12,9 +12,6 @@ import re
 import sys
 from typing import TYPE_CHECKING
 
-from shared.config import get_config
-from shared.deduplication import is_known
-
 if TYPE_CHECKING:
     from typing import Any
 
@@ -98,6 +95,12 @@ def main() -> None:
 
     if not urls:
         sys.exit(0)
+
+    # Imported here, not at module scope: this hook runs on every
+    # prompt and `shared` pulls in memory_palace.paths and xxhash,
+    # about 100ms that a prompt with no URL has no use for.
+    from shared.config import get_config
+    from shared.deduplication import is_known
 
     config = get_config()
     if not config.get("enabled", True):

--- a/plugins/memory-palace/tests/hooks/test_url_detector.py
+++ b/plugins/memory-palace/tests/hooks/test_url_detector.py
@@ -91,3 +91,41 @@ class TestExtractUrls:
         urls = extract_urls(text)
         assert len(urls) == 1
         assert "docs.example.com" in urls[0]
+
+
+class TestQuietPathImports:
+    """Feature: a prompt with no URL costs nothing but the regex.
+
+    This hook is one of five on UserPromptSubmit, an event that blocks
+    the turn and that telemetry showed timing out on roughly 16% of
+    prompts. `shared.config` and `shared.deduplication` pull in
+    memory_palace.paths and xxhash, about 100ms measured with
+    `python -X importtime`, and neither is reachable until a URL has
+    already been found. Its sibling `recall.py` pins the same contract
+    for the same reason.
+    """
+
+    def test_shared_package_is_not_imported_at_module_scope(self) -> None:
+        """Scenario: a promptless-of-URLs turn pays only for the regex."""
+        import ast
+        from pathlib import Path
+
+        hook = Path(__file__).resolve().parents[2] / "hooks" / "url_detector.py"
+        tree = ast.parse(hook.read_text())
+        toplevel = {
+            node.module
+            for node in tree.body
+            if isinstance(node, ast.ImportFrom) and node.module
+        }
+        toplevel |= {
+            alias.name
+            for node in tree.body
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        }
+        offenders = {
+            name for name in toplevel if name.startswith(("shared", "memory_palace"))
+        }
+        assert not offenders, (
+            f"imported at module scope, so every prompt pays for them: {offenders}"
+        )

--- a/plugins/pensive/hooks/hooks.json
+++ b/plugins/pensive/hooks/hooks.json
@@ -3,12 +3,12 @@
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "if": "Bash(gh pr create*)",
         "hooks": [
           {
             "type": "command",
             "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/pr_blast_radius.py",
-            "timeout": 5
+            "timeout": 5,
+            "if": "Bash(gh pr create*)"
           }
         ]
       }

--- a/plugins/sanctum/hooks/post_implementation_policy.py
+++ b/plugins/sanctum/hooks/post_implementation_policy.py
@@ -28,64 +28,26 @@ LIGHTWEIGHT_AGENTS = frozenset(
 )
 
 GOVERNANCE_POLICY = """
-## Mandatory Post-Implementation Protocol
+## Post-Implementation Protocol
 
-<GOVERNANCE_RULE priority="high" override="false">
-Before reporting completion of ANY of the following:
-- Feature implementation
-- Plan execution (especially Skill(superpowers:executing-plans))
-- Significant code changes
-- New functionality added
+<GOVERNANCE_RULE priority="high">
+Applies before you report a feature, a plan execution, or a significant
+code change as complete. It does not apply to questions, explanations,
+bug fixes that add no behavior, refactors, or exploration.
 
-You MUST execute these commands IN ORDER:
+Run these in order:
 
-1. **PROOF-OF-WORK + IRON LAW** (MANDATORY FIRST) - Invoke `Skill(imbue:proof-of-work)`:
-   - Create TodoWrite items: `proof:problem-reproduced`,
-     `proof:solution-tested`, `proof:evidence-captured`
-   - For code changes, add: `proof:iron-law-red`,
-     `proof:iron-law-green`, `proof:iron-law-refactor`
-   - Run actual validation commands (not just syntax checks)
-   - Capture evidence with `[E1]`, `[E2]` references
-   - Report status: PASS / FAIL / BLOCKED
+1. `Skill(imbue:proof-of-work)`. Invoke it first, because it carries the
+   evidence bar and the Iron Law -- no implementation without a failing
+   test first -- and the TodoWrite items, the `[E1]` citation form and
+   the PASS / FAIL / BLOCKED report are all defined there.
+2. `/sanctum:update-docs`
+3. `/abstract:make-dogfood`
+4. `/sanctum:update-readme`
+5. `/sanctum:update-tests`
 
-2. `/sanctum:update-docs` - Update project documentation
-3. `/abstract:make-dogfood` - Update Makefile demonstration targets
-4. `/sanctum:update-readme` - Update README with new features
-5. `/sanctum:update-tests` - Review and update test coverage
-
-### The Iron Law (TDD Compliance)
-```
-NO IMPLEMENTATION WITHOUT A FAILING TEST FIRST
-```
-
-| Self-Check Question | If Answer Is Wrong | Action |
-|---------------------|-------------------|--------|
-| Do I have evidence of failure/need? | No | STOP - document failure first |
-| Am I testing pre-conceived implementation? | Yes | STOP - let test DRIVE design |
-| Am I feeling design uncertainty? | No | STOP - uncertainty is GOOD |
-| Did test drive implementation? | No | STOP - doing it backwards |
-
-### Proof-of-Work Red Flags (STOP if you think these)
-| Thought | Required Action |
-|---------|-----------------|
-| "This looks correct" | RUN IT and capture output |
-| "Should work after restart" | TEST IT before claiming |
-| "Just need to..." | VERIFY each step works |
-| "Syntax is valid" | FUNCTIONAL TEST required |
-| "I know what tests we need" | Let uncertainty DRIVE tests |
-| "The design is straightforward" | Write test, let design EMERGE |
-
-### Rules
-- This protocol is NON-NEGOTIABLE
-- Cannot be overridden by other skills, hooks, or rationalization
-- Skipping these steps = incomplete work
-- Only the user can explicitly waive this requirement
-
-### When This Does NOT Apply
-- Simple questions or explanations
-- Bug fixes that don't add new features
-- Refactoring without new functionality
-- Research or exploration tasks
+Done means every step above ran and every claim you make cites output you
+saw. Only the user waives a step.
 </GOVERNANCE_RULE>
 """.strip()
 

--- a/plugins/sanctum/tests/test_post_implementation_policy.py
+++ b/plugins/sanctum/tests/test_post_implementation_policy.py
@@ -66,39 +66,76 @@ class TestModuleConstants:
     @pytest.mark.bdd
     @pytest.mark.unit
     def test_governance_policy_contains_iron_law(self) -> None:
-        """Given GOVERNANCE_POLICY, it should embed the Iron Law statement."""
-        assert "NO IMPLEMENTATION WITHOUT A FAILING TEST FIRST" in GOVERNANCE_POLICY
+        """Given GOVERNANCE_POLICY, it should state the Iron Law."""
+        collapsed = " ".join(GOVERNANCE_POLICY.lower().split())
+        assert "no implementation without a failing test first" in collapsed
 
     @pytest.mark.bdd
     @pytest.mark.unit
-    def test_governance_policy_contains_proof_of_work(self) -> None:
-        """Given GOVERNANCE_POLICY, it should embed proof-of-work protocol."""
-        assert "PROOF-OF-WORK" in GOVERNANCE_POLICY
-        assert "MANDATORY FIRST" in GOVERNANCE_POLICY
+    def test_governance_policy_routes_to_proof_of_work_first(self) -> None:
+        """Given GOVERNANCE_POLICY, proof-of-work precedes the doc commands."""
+        assert "Skill(imbue:proof-of-work)" in GOVERNANCE_POLICY
+        assert GOVERNANCE_POLICY.index("proof-of-work") < GOVERNANCE_POLICY.index(
+            "/sanctum:update-docs"
+        )
 
     @pytest.mark.bdd
     @pytest.mark.unit
-    def test_governance_policy_contains_iron_law_todo_items(self) -> None:
-        """Given GOVERNANCE_POLICY, it should mention iron-law TodoWrite items."""
-        for item in ("iron-law-red", "iron-law-green", "iron-law-refactor"):
-            assert item in GOVERNANCE_POLICY, f"Missing TodoWrite item: {item}"
+    def test_governance_policy_lists_every_step_command(self) -> None:
+        """Given GOVERNANCE_POLICY, all four follow-up commands are named."""
+        for command in (
+            "/sanctum:update-docs",
+            "/abstract:make-dogfood",
+            "/sanctum:update-readme",
+            "/sanctum:update-tests",
+        ):
+            assert command in GOVERNANCE_POLICY, f"Missing step: {command}"
 
     @pytest.mark.bdd
     @pytest.mark.unit
-    def test_governance_policy_contains_self_check_table(self) -> None:
-        """Given GOVERNANCE_POLICY, it should contain self-check questions."""
-        assert "Self-Check" in GOVERNANCE_POLICY
+    def test_governance_policy_bounds_where_it_applies(self) -> None:
+        """Given GOVERNANCE_POLICY, the exempt cases stay stated.
+
+        The exemptions are the half a session cannot derive. Without them
+        the protocol reads as applying to answering a question.
+        """
         lower = GOVERNANCE_POLICY.lower()
-        assert "evidence" in lower
-        assert "pre-conceived" in lower
-        assert "uncertainty" in lower
+        for exemption in ("question", "refactor", "exploration"):
+            assert exemption in lower, f"Missing exemption: {exemption}"
 
     @pytest.mark.bdd
     @pytest.mark.unit
-    def test_governance_policy_contains_red_flags(self) -> None:
-        """Given GOVERNANCE_POLICY, it should contain red-flag rationalisations."""
-        assert "This looks correct" in GOVERNANCE_POLICY
-        assert "RUN IT" in GOVERNANCE_POLICY
+    def test_governance_policy_carries_no_rationalization_table(self) -> None:
+        """Given GOVERNANCE_POLICY, retired persuasion patterns are absent.
+
+        `.claude/rules/bounded-autonomy.md` retires rationalization tables
+        and unfalsifiable override claims by name, and asks that they be
+        removed from any file being edited. This payload is injected into
+        every session, so it is the most expensive place to keep them.
+        """
+        for retired in (
+            "This looks correct",
+            "Cannot be overridden",
+            "NON-NEGOTIABLE",
+            "Self-Check",
+        ):
+            assert retired not in GOVERNANCE_POLICY, (
+                f"retired persuasion pattern is back: {retired!r}"
+            )
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_governance_policy_stays_within_its_injection_budget(self) -> None:
+        """Given GOVERNANCE_POLICY, it stays small enough to inject always.
+
+        This text is prepended to every session that is not a lightweight
+        agent, whatever the session turns out to be about. It was 2,553
+        characters; the budget is what stops it growing back.
+        """
+        assert len(GOVERNANCE_POLICY) <= 1200, (
+            f"{len(GOVERNANCE_POLICY)} chars injected into every session; "
+            "move detail into a skill body and point at it instead"
+        )
 
     @pytest.mark.bdd
     @pytest.mark.unit
@@ -150,7 +187,7 @@ class TestFullGovernancePath:
         output = json.loads(captured_stdout.getvalue())
         context = output["hookSpecificOutput"]["additionalContext"]
         assert "Iron Law" in context
-        assert "PROOF-OF-WORK" in context
+        assert "Skill(imbue:proof-of-work)" in context
 
     @pytest.mark.bdd
     @pytest.mark.unit

--- a/scripts/check_hook_modernization.py
+++ b/scripts/check_hook_modernization.py
@@ -220,6 +220,69 @@ def check_python_source(
     return findings
 
 
+def check_hooks_json_config(
+    config: dict[str, object],
+    plugin: str,
+) -> list[Finding]:
+    """Return findings for `if` conditions the harness will not read.
+
+    Measured on Claude Code 2.1.245: a PreToolUse hook whose entry
+    carries ``"if": "Bash(zzzznevermatch*)"`` is not spawned, and the
+    identical key on the enclosing matcher group is dropped without an
+    error, leaving the hook to fire on every matching call. The failure
+    is silent in both directions -- JSON has no schema here, so the
+    config reads as gated while the process count says otherwise.
+    """
+    findings: list[Finding] = []
+    hooks = config.get("hooks", config)
+    if not isinstance(hooks, dict):
+        return findings
+
+    for event, groups in hooks.items():
+        if not isinstance(groups, list):
+            continue
+        for group in groups:
+            if not isinstance(group, dict) or "if" not in group:
+                continue
+            findings.append(
+                Finding(
+                    plugin=plugin,
+                    file="hooks.json",
+                    pattern="misplaced-if-condition",
+                    severity="error",
+                    message=(
+                        f"{event}: 'if' sits on the matcher group, where "
+                        f"the harness ignores it, so {group['if']!r} gates "
+                        "nothing. Move it into the hook entry, beside "
+                        "'command'."
+                    ),
+                )
+            )
+        for group in groups:
+            if not isinstance(group, dict):
+                continue
+            for entry in group.get("hooks", []):
+                if not isinstance(entry, dict) or "if" not in entry:
+                    continue
+                if isinstance(entry["if"], str):
+                    continue
+                findings.append(
+                    Finding(
+                        plugin=plugin,
+                        file="hooks.json",
+                        pattern="non-string-if-condition",
+                        severity="error",
+                        message=(
+                            f"{event}: 'if' must be a single string. An "
+                            "array suppressed the hook outright when "
+                            "measured, matching rule included, so the hook "
+                            "never runs. Split it into one entry per rule."
+                        ),
+                    )
+                )
+    return findings
+
+
 def run_audit(repo_root: Path) -> AuditResult:
     """Run the full modernization audit."""
     result = AuditResult()
@@ -272,6 +335,16 @@ def run_audit(repo_root: Path) -> AuditResult:
 
         findings = check_python_source(source, plugin_name, py_file.name, event_types)
         result.findings.extend(findings)
+
+    for hooks_json in find_hooks_json(repo_root):
+        try:
+            config = json.loads(hooks_json.read_text())
+        except (json.JSONDecodeError, OSError):
+            # Already reported as unparseable-hooks-json above.
+            continue
+        result.findings.extend(
+            check_hooks_json_config(config, hooks_json.parent.parent.name)
+        )
 
     return result
 

--- a/scripts/run-plugin-tests.sh
+++ b/scripts/run-plugin-tests.sh
@@ -98,7 +98,7 @@ run_plugin_tests() {
 
             # Run using uv/pytest - capture output, show on failure.
             # Redirect stdout before stderr; see the Makefile branch above.
-            if (cd "$plugin_dir" && "$WITHOUT_GIT_ENV" uv run python -m pytest tests/ --tb=short --quiet "${cov_flag[@]}" > "$temp_output" 2>&1); then
+            if (cd "$plugin_dir" && "$WITHOUT_GIT_ENV" uv run python -m pytest tests/ --tb=short --quiet ${cov_flag[@]+"${cov_flag[@]}"} > "$temp_output" 2>&1); then
                 echo -e "  ${GREEN}✓ Tests passed${NC}"
                 PASSED_PLUGINS+=("$plugin_name")
                 rm -f "$temp_output"
@@ -107,7 +107,7 @@ run_plugin_tests() {
                 echo -e "  ${RED}✗ Tests failed${NC}"
                 echo -e "${YELLOW}Re-running with verbose output:${NC}"
                 echo
-                (cd "$plugin_dir" && "$WITHOUT_GIT_ENV" uv run python -m pytest tests/ --tb=short "${cov_flag[@]}" 2>&1)
+                (cd "$plugin_dir" && "$WITHOUT_GIT_ENV" uv run python -m pytest tests/ --tb=short ${cov_flag[@]+"${cov_flag[@]}"} 2>&1)
                 FAILED_PLUGINS+=("$plugin_name")
                 rm -f "$temp_output"
                 return 1

--- a/tests/unit/test_check_hook_modernization.py
+++ b/tests/unit/test_check_hook_modernization.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 from check_hook_modernization import (
     AuditResult,
     Finding,
+    check_hooks_json_config,
     check_python_source,
     format_json,
     format_text,
@@ -659,3 +660,155 @@ class TestSilentDropSurfacing:
         bad.write_text("{ not json")
         with pytest.raises(json.JSONDecodeError):
             get_hook_event_types(bad)
+
+
+# ============================================================================
+# check_hooks_json_config: `if` placement (measured on CLI 2.1.245)
+# ============================================================================
+
+
+class TestMisplacedIfCondition:
+    """Feature: Detect an `if` condition the harness will silently ignore.
+
+    Measured on CLI 2.1.245: an `if` key on the matcher-group object is
+    dropped, so the hook fires on every matching tool call. The same key
+    inside the hook entry suppresses the spawn. A misplaced key produces
+    a config that reads as gated and behaves as ungated, with no error.
+    """
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_flags_if_on_matcher_group(self):
+        config = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "if": "Bash(git commit*)",
+                        "hooks": [{"type": "command", "command": "gate.py"}],
+                    }
+                ]
+            }
+        }
+        findings = check_hooks_json_config(config, "gauntlet")
+        assert [f.pattern for f in findings] == ["misplaced-if-condition"]
+        assert findings[0].severity == "error"
+        assert "hook entry" in findings[0].message
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_accepts_if_inside_hook_entry(self):
+        config = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "gate.py",
+                                "if": "Bash(git commit*)",
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        assert check_hooks_json_config(config, "gauntlet") == []
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_accepts_group_with_no_if(self):
+        config = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": "x.py"}],
+                    }
+                ]
+            }
+        }
+        assert check_hooks_json_config(config, "pensive") == []
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_reports_every_misplaced_group(self):
+        group = {
+            "matcher": "Bash",
+            "if": "Bash(git commit*)",
+            "hooks": [{"type": "command", "command": "x.py"}],
+        }
+        config = {"hooks": {"PreToolUse": [dict(group)], "PostToolUse": [dict(group)]}}
+        findings = check_hooks_json_config(config, "gauntlet")
+        assert len(findings) == 2
+        assert {f.file for f in findings} == {"hooks.json"}
+
+
+class TestShippedHooksJsonPlacement:
+    """Feature: no shipped hooks.json carries a silently-ignored `if`."""
+
+    @pytest.mark.bdd
+    @pytest.mark.integration
+    def test_no_plugin_ships_a_misplaced_if(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        offenders = []
+        for hooks_json in sorted(repo_root.glob("plugins/*/hooks/hooks.json")):
+            config = json.loads(hooks_json.read_text())
+            plugin = hooks_json.parts[-3]
+            offenders.extend(
+                f"{plugin}: {f.message}"
+                for f in check_hooks_json_config(config, plugin)
+            )
+        assert offenders == []
+
+
+class TestNonStringIfCondition:
+    """Feature: an array-valued `if` is a silent kill switch.
+
+    Measured on CLI 2.1.245: an entry whose `if` is a list is never
+    spawned, even when one element of the list matches the command.
+    """
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_flags_array_valued_if(self):
+        config = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "gate.py",
+                                "if": ["Bash(git commit*)", "Bash(pip install*)"],
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        findings = check_hooks_json_config(config, "imbue")
+        assert [f.pattern for f in findings] == ["non-string-if-condition"]
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_accepts_string_if(self):
+        config = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "gate.py",
+                                "if": "Bash(git commit*)",
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        assert check_hooks_json_config(config, "imbue") == []

--- a/tests/unit/test_run_plugin_tests.py
+++ b/tests/unit/test_run_plugin_tests.py
@@ -461,3 +461,48 @@ class TestTestsWithoutConfigAreAFailure:
             f"{result.stdout}"
         )
         assert "real" in result.stdout
+
+
+class TestEmptyCoverageFlagUnderSetU:
+    """Feature: a plugin with no coverage_threshold still runs its tests.
+
+    bash 3.2, which is what macOS ships, treats an empty array as unset,
+    so `"${cov_flag[@]}"` under `set -u` aborts the script with
+    `cov_flag[@]: unbound variable` before pytest is ever invoked. Every
+    plugin without a threshold -- cartograph among them -- reported
+    "Tests failed" having run no tests. bash 4+ does not reproduce it,
+    which is why it survived CI.
+    """
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_empty_array_expansion_survives_set_u(self):
+        expansions = re.findall(r"\$\{?cov_flag\[@\][^\n]{0,24}", SCRIPT.read_text())
+        assert expansions, "cov_flag expansion disappeared; update this test"
+        for expansion in expansions:
+            assert expansion.startswith("${cov_flag[@]+"), (
+                f"{expansion!r} aborts under `set -u` on bash 3.2; use the "
+                '${cov_flag[@]+"${cov_flag[@]}"} guarded form'
+            )
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_guarded_form_expands_to_nothing_when_empty(self):
+        script = 'set -u; cov_flag=(); set -- ${cov_flag[@]+"${cov_flag[@]}"}; echo $#'
+        result = subprocess.run(
+            ["bash", "-c", script], capture_output=True, text=True, check=False
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "0"
+
+    @pytest.mark.bdd
+    @pytest.mark.unit
+    def test_guarded_form_still_passes_a_set_threshold(self):
+        script = (
+            "set -u; cov_flag=(--cov-fail-under=85); "
+            'set -- ${cov_flag[@]+"${cov_flag[@]}"}; echo "$# $1"'
+        )
+        result = subprocess.run(
+            ["bash", "-c", script], capture_output=True, text=True, check=False
+        )
+        assert result.stdout.strip() == "1 --cov-fail-under=85"

--- a/tests/unit/test_session_start_injection_budget.py
+++ b/tests/unit/test_session_start_injection_budget.py
@@ -1,0 +1,90 @@
+"""Gate: what SessionStart injects stays small enough to inject always.
+
+Eight plugins register `SessionStart`, and whatever they print is
+prepended to every session before the user has said what the session is
+for. Three of them carried reference manuals -- 9,973 of the 10,770
+characters measured across the set -- so most sessions paid for guidance
+about work they were never going to do.
+
+`.claude/rules/bounded-autonomy.md` is the reason this gate exists rather
+than a style note. It cites a STAR-structured prompt that scored 100% on
+a reasoning task alone and 0% inside a 60-line production prompt grown by
+iterative additions of style and format instructions, and names this
+repository's session-start injections as the same shape. A second paper
+it cites found that a constraint the model was *already satisfying* still
+cost accuracy. Injected text is not free when it is right.
+
+The budget is what stops regrowth. Detail belongs in a skill body, which
+is loaded when the task calls for it; the injection should be the pointer.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Per-hook ceiling on injected characters. Each was set just above what
+# the trimmed payload measures, so a manual cannot creep back without
+# turning this red.
+BUDGETS = {
+    "conserve/hooks/session-start.sh": 1200,
+    "imbue/hooks/session-start.sh": 1400,
+}
+
+HOOK_INPUT = json.dumps({"session_id": "budget-probe", "source": "startup"})
+
+
+def _injected_context(hook: Path) -> str:
+    """Run *hook* as Claude Code would and return what it injects."""
+    result = subprocess.run(
+        ["bash", str(hook)],
+        input=HOOK_INPUT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    return payload["hookSpecificOutput"]["additionalContext"]
+
+
+@pytest.mark.parametrize(("relative_path", "budget"), sorted(BUDGETS.items()))
+def test_injection_stays_within_budget(relative_path: str, budget: int) -> None:
+    """Scenario: a session-start payload cannot grow back into a manual."""
+    context = _injected_context(REPO_ROOT / "plugins" / relative_path)
+    assert len(context) <= budget, (
+        f"{relative_path} injects {len(context)} chars into every session "
+        f"(budget {budget}). Move the detail into a skill body and inject a "
+        "pointer to it."
+    )
+
+
+@pytest.mark.parametrize("relative_path", sorted(BUDGETS))
+def test_injection_still_routes_to_a_skill(relative_path: str) -> None:
+    """Scenario: trimming did not leave a payload that points nowhere.
+
+    A budget alone is satisfied by deleting the text. The injection has
+    to still say which skill carries what was removed.
+    """
+    context = _injected_context(REPO_ROOT / "plugins" / relative_path)
+    assert "Skill(" in context, f"{relative_path} names no skill to route to"
+
+
+def test_the_two_hooks_do_not_both_carry_scope_guard() -> None:
+    """Scenario: the same quick reference is not injected twice.
+
+    conserve's payload used to end with a "Scope-Guard Principles (from
+    imbue)" section restating imbue's own injection, so every session
+    paid for the worthiness formula and the branch thresholds twice.
+    """
+    conserve = _injected_context(REPO_ROOT / "plugins/conserve/hooks/session-start.sh")
+    assert "imbue:scope-guard" not in conserve, (
+        "conserve injects imbue's scope-guard reference; imbue already does"
+    )


### PR DESCRIPTION
Addresses the hook and context-budget items from a `/doctor` report
(50 sessions, 6 projects, 2026-08-05 to 2026-08-25, CLI 2.1.245, 1M
context). The reported telemetry is from another machine and is not
reproducible here; every claim below is measured in this checkout unless
it is labelled as the report's.

## The finding that changed the shape of the work

The report asked for narrower `PreToolUse` matchers. Before adding any, I
probed how the `if` field actually behaves on 2.1.245, with a marker file
per hook:

| Placement | Condition | Result |
|-----------|-----------|--------|
| Matcher-group level | `Bash(zzzznevermatch*)` | **FIRED** -- key ignored |
| Hook-entry level | `Bash(zzzznevermatch*)` | suppressed |
| Hook-entry level | `Bash(echo *)` on `echo needle-here` | fired |
| Hook-entry level | `Bash(echo *)` on `true && echo hay` | fired -- compound split per segment |
| Hook-entry level | `Bash(*needle*)` on `echo needle-here` | fired -- leading wildcard works |
| Hook-entry level | `if` as a JSON array containing a matching rule | suppressed -- silent kill switch |

Every `if` this repo shipped was on the matcher group. `gauntlet` (2),
`pensive` (1) and `cartograph` (1) read as gated and were firing on every
Bash call. `plugins/abstract/skills/hook-authoring/modules/hook-types.md`
documented the correct placement, so the docs were right and the configs
were wrong. `hooks.json` has no schema, so nothing errored.

## What changed

**Hook gating.** Moved the four no-op gates into their hook entries, then
gated imbue's three `PreToolUse:Bash` hooks, which parse commands with
anchored regexes and exited early on nearly every call. Because `if`
splits compound commands and matches globs, each gate is a strict superset
of what its hook acts on. The package guard gets one rule per shape in
`_INSTALL_HEADS` rather than one broad rule: a rule narrower than the
parser would disable typosquat checking for an ecosystem with no signal.
`scripts/check_hook_modernization.py` now rejects both failure modes.

**conserve/context_warning.py** re-read up to 4MB of session transcript and
JSON-parsed every line on each Write/Edit/Bash/Skill/Task, with nothing
carried between calls. The alert bands are 40/50/80%, so per-call
resolution bought no accuracy. Cached for 30s, keyed on the resolved
transcript path, opened with `O_NOFOLLOW` plus an ownership check because
that path is predictable (CWE-59, the defense imbue keeps in
`shared/vow_utils.py`).

**memory-palace/url_detector.py** imported `shared.config` and
`shared.deduplication` at module scope: 100ms by `-X importtime`, on every
prompt, for names unreachable until a URL is found. Deferred. Quiet path
90ms to 40ms.

**SessionStart.** Three payloads carried reference manuals -- 9,973 of the
10,770 characters measured across eight registrations. Now 2,743, with the
detail behind the skills that already held it.
`.claude/rules/bounded-autonomy.md` names this shape and retires the
rationalization tables all three carried. conserve additionally stopped
restating imbue's scope-guard reference, which every session paid for twice.

| Hook | Before | After |
|------|--------|-------|
| conserve/session-start.sh | ~4,000 | 951 |
| imbue/session-start.sh | ~3,100 | 990 |
| sanctum/post_implementation_policy.py | 2,553 | 802 |

## Two pre-existing failures fixed to land this

Both blocked every commit against master, whatever it touched:

- `plugins/conjure` shipped a git-tracked skill that `plugin.json` never
  registered. Registering it also required the capabilities row and a
  description trim to the 160-char cap.
- `scripts/run-plugin-tests.sh` aborted under bash 3.2 -- what macOS ships
  -- for any plugin with no coverage threshold, reporting "Tests failed"
  having run no tests. bash 4+ does not reproduce it, so CI never saw it.

## Verification

4,660 repo tests plus the touched plugin suites pass. New guards:
`check_hooks_json_config` for both `if` failure modes, a gate-coverage test
per `_INSTALL_HEADS` entry, cache and symlink-refusal tests, an
import-scope test mirroring `recall.py`'s, and a per-payload SessionStart
budget that also asserts each still names a skill to route to.

## Notes for review

- `Bash(*pip*)` also admits `pipeline` and `pipx`. Superset by design, so
  coverage holds, but the package-guard spawn count will not reach zero in
  a repo where "pipeline" is a common word.
- The `minimax-delegation` registration may collide with
  `fix/minimax-cli-contract`, which is likely carrying the same fix.
- No claim is made that a specific reported number moved. The 26s Bash
  outlier is not reproducible here and was not chased as a number; the
  structural fixes stand on their own.

## Deferred, with issues

- #779 -- five `UserPromptSubmit` registrations. The event takes no `if`,
  so consolidation is a cross-plugin change and is out of scope here.
- #778 -- six plugins never invoked in 350 startups, and the skill-listing
  budget they sit inside.