### PR TITLE
Normalise the hooks path so equivalent spellings are caught

### DIFF
--- a/scripts/check_plugin_hooks.py
+++ b/scripts/check_plugin_hooks.py
@@ -16,9 +16,33 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+import posixpath
 
 # The default hooks file that Claude Code auto-loads.
 _AUTO_LOADED = "./hooks/hooks.json"
+
+#: The same path, normalised, for COMPARISON only. `_AUTO_LOADED` stays
+#: exactly as it was so the error message a user sees is unchanged.
+_AUTO_LOADED_NORM = "hooks/hooks.json"
+
+
+def _norm(entry) -> str:
+    """Normalise a hooks-array entry so every spelling of one path compares equal.
+
+    The check below used to be an exact match against "./hooks/hooks.json", so
+    three other spellings of the SAME file passed the hook and then produced the
+    very "Duplicate hooks file" error it exists to prevent:
+
+        ./hooks/hooks.json     caught
+        hooks/hooks.json       missed
+        hooks//hooks.json      missed
+        ./hooks/./hooks.json   missed
+
+    posixpath.normpath collapses "//" and "/./"; the lstrip removes a leading
+    "./". Plugin manifests use forward slashes on every platform, so posixpath
+    is correct here rather than os.path.
+    """
+    return posixpath.normpath(str(entry).strip()).lstrip("./")
 
 
 def check_file(path: Path) -> list[str]:
@@ -31,7 +55,7 @@ def check_file(path: Path) -> list[str]:
         return errors
 
     hooks = data.get("hooks", [])
-    if _AUTO_LOADED in hooks:
+    if any(_norm(h) == _AUTO_LOADED_NORM for h in hooks):
         errors.append(
             f"  {path}: hooks array contains '{_AUTO_LOADED}' which is "
             f"auto-loaded by Claude Code. Remove it to avoid duplicate "

--- a/tests/unit/test_check_plugin_hooks.py
+++ b/tests/unit/test_check_plugin_hooks.py
@@ -20,6 +20,48 @@ class TestCheckPluginHooks:
     """Verify detection of the auto-loaded hooks/hooks.json in manifests."""
 
     @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "spelling",
+        ["hooks/hooks.json", "hooks//hooks.json", "./hooks/./hooks.json"],
+    )
+    def test_rejects_equivalent_spellings_of_the_auto_loaded_path(
+        self, tmp_path: Path, spelling: str
+    ) -> None:
+        """
+        Scenario: plugin.json lists the auto-loaded hooks file, spelled differently
+        Given a plugin.json whose hooks array holds another spelling of ./hooks/hooks.json
+        When check_file runs
+        Then it still returns an error about duplicate hooks
+
+        These three passed the check before the comparison was normalised, and
+        each one names the same file Claude Code auto-loads -- so each produced
+        the "Duplicate hooks file" error this hook exists to prevent.
+        """
+        manifest = tmp_path / "plugin.json"
+        manifest.write_text(json.dumps({"name": "test-plugin", "hooks": [spelling]}))
+        errors = check_file(manifest)
+        assert errors, f"{spelling!r} names the auto-loaded file and must be rejected"
+
+    @pytest.mark.parametrize(
+        "spelling",
+        ["./hooks/extra.json", "hooks/other/hooks.json", "hooks/hooks2.json"],
+    )
+    def test_allows_genuinely_additional_hook_files(
+        self, tmp_path: Path, spelling: str
+    ) -> None:
+        """
+        Scenario: plugin.json lists a hook file that is NOT the auto-loaded one
+        Given a plugin.json whose hooks array holds an additional hook file
+        When check_file runs
+        Then it returns no errors
+
+        The negative half of the case above: normalising the comparison must not
+        start rejecting the additional files the hooks array is FOR.
+        """
+        manifest = tmp_path / "plugin.json"
+        manifest.write_text(json.dumps({"name": "test-plugin", "hooks": [spelling]}))
+        assert check_file(manifest) == []
+
     def test_rejects_explicit_hooks_json(self, tmp_path: Path) -> None:
         """
         Scenario: plugin.json lists the auto-loaded hooks file


### PR DESCRIPTION
## The problem

`scripts/check_plugin_hooks.py` compares each `hooks` entry **exactly** against `"./hooks/hooks.json"`. Three other spellings of that same file pass the pre-commit hook and then produce the "Duplicate hooks file" error at session start that the hook exists to prevent.

Reproduced by writing one `plugin.json` per row and running the checker directly on it:

| `hooks[0]` | result |
|---|---|
| `./hooks/hooks.json` | exit 1, **caught** — positive control, the hook works |
| `hooks/hooks.json` | exit 0, **missed** |
| `hooks//hooks.json` | exit 0, **missed** |
| `./hooks/./hooks.json` | exit 0, **missed** |

The first row is the control: the mechanism is sound, the comparison is just too narrow.

## The fix

Normalise before comparing — `posixpath.normpath` collapses `//` and `/./`, and an `lstrip("./")` removes a leading `./`. Plugin manifests use forward slashes on every platform, so `posixpath` is right here rather than `os.path`.

**The user-facing message is unchanged.** `_AUTO_LOADED` keeps its original value and a separate `_AUTO_LOADED_NORM` is used only for the comparison, so the existing tests that pin the error text still pass.

## Tests

Six added — three positive (each missed spelling must now be rejected) and three negative (`./hooks/extra.json`, `hooks/other/hooks.json`, `hooks/hooks2.json` must still be allowed, so normalising cannot start rejecting the additional files the `hooks` array is *for*).

Verified both ways: reverting the one-line comparison change fails exactly the three new positive tests and leaves the negative ones green. `tests/unit/test_check_plugin_hooks.py` is 14/14 with the fix, 11/14 without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UznkdgH2feZgGejSywk9sK