### PR TITLE
fix(gauntlet): judge the scanned tree, not where it sits on disk

### DIFF
--- a/plugins/gauntlet/src/gauntlet/extraction.py
+++ b/plugins/gauntlet/src/gauntlet/extraction.py
@@ -115,7 +115,8 @@ def extract_from_directory(
     for py_file in sorted(directory.rglob("*.py")):
         if py_file.name.startswith("__"):
             continue
-        if any(_is_vendor_dir(part) for part in py_file.parent.parts):
+        relative_parent = py_file.parent.relative_to(directory)
+        if any(_is_vendor_dir(part) for part in relative_parent.parts):
             continue
         if exclude_patterns and any(py_file.match(pat) for pat in exclude_patterns):
             continue

--- a/plugins/gauntlet/tests/unit/test_extraction.py
+++ b/plugins/gauntlet/tests/unit/test_extraction.py
@@ -436,6 +436,39 @@ class TestExtractFromDirectory:
         assert "func_stale" not in concepts
 
     @pytest.mark.unit
+    def test_a_dot_prefixed_ancestor_does_not_exclude_the_scanned_tree(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        Scenario: The project is scanned from inside a dot-prefixed directory
+        Given a scan root beneath an ancestor such as .claude
+        When extract_from_directory() is called on that root
+        Then the project's own entries are still returned
+
+        The installed layout is exactly this shape. extract is documented
+        as `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/extractor.py <dir>`, and
+        CLAUDE_PLUGIN_ROOT resolves under ~/.claude/plugins, so judging the
+        ancestor rather than the scanned tree returned nothing at all, with
+        no error and no partial-scan indicator.
+
+        tmp_path never contains a dot component, which is why the vendor
+        tests above pass against the defect.
+        """
+        root = tmp_path / ".claude" / "plugins" / "project"
+        root.mkdir(parents=True)
+        (root / "mine.py").write_text(
+            textwrap.dedent("""\
+            def func_under_dot_ancestor():
+                \"\"\"Project code.\"\"\"
+                pass
+        """)
+        )
+
+        entries = extract_from_directory(root)
+
+        assert [e.concept for e in entries] == ["func_under_dot_ancestor"]
+
+    @pytest.mark.unit
     def test_exclude_patterns_are_applied_under_recursion(self, tmp_path: Path) -> None:
         """
         Scenario: A caller excludes generated modules


### PR DESCRIPTION
## Summary

Refs #784, finding B1.

`extract_from_directory` returned zero entries for every installed
user, with no error and no partial-scan indicator.

## What the code actually did

`1ae1eff2` made the walk recursive and added a vendor skip so it would
not descend into `.venv` and `site-packages`. The skip tests
`py_file.parent.parts`, which is the whole path and usually absolute, so
a dot-prefixed **ancestor** excludes everything beneath it.

`skills/extract/SKILL.md:23` documents the invocation as
`python3 ${CLAUDE_PLUGIN_ROOT}/scripts/extractor.py <target-dir>`, and
`CLAUDE_PLUGIN_ROOT` resolves under `~/.claude/plugins`. The installed
layout is the failing case.

| Scan root | Before | After |
|---|---|---|
| `/tmp/.dotproof/plugins/project` | 0 entries | 1 entry |
| `/tmp/nodotproof/plugins/project` | 1 entry | 1 entry |

Same file content in both trees. The ancestor is the only variable.

## Changes

**One line, plus a name for the intermediate.** The filter compares
against `py_file.parent.relative_to(directory)` rather than
`py_file.parent`, so it judges the tree the caller asked about instead
of where that tree happens to live.

A `.venv` placed *inside* the scanned root is still skipped. That was
the point of the original change and it is unaffected.

## Test plan

One regression test, verified red before the fix.

- [x] `test_a_dot_prefixed_ancestor_does_not_exclude_the_scanned_tree`
      builds its root under `.claude/plugins/project`. Red before,
      green after.
- [x] The two tests from `1ae1eff2` still pass. They pass against the
      defect too, because pytest's `tmp_path` never contains a dot
      component, which is why this shipped. Same fixture blind spot
      `d61ccff5` recorded on this branch for a different test.
- [x] `plugins/gauntlet`: 524 passed
- [x] Vendored exclusion re-checked by hand: a `.venv/lib/dep.py` under
      the scanned root contributes nothing, concepts are `['func_probe']`

## Base

Targets `fix-recent-1.9.20` rather than `master`. The defect was
introduced on that branch by `1ae1eff2` and does not exist on `master`.

## Not done

The other three blocking findings from the #784 audit are pre-existing
and unrelated to this regression: the `permission_request.py` newline
bypass, the Go tree-sitter parser, and the two graph hooks reading
`tool_result`. Each has its own discussion. Bundling them here would
make this diff unreviewable.
